### PR TITLE
feat: settings confirmation

### DIFF
--- a/lact-daemon/src/server/gpu_controller/mod.rs
+++ b/lact-daemon/src/server/gpu_controller/mod.rs
@@ -407,6 +407,9 @@ impl GpuController {
             self.handle.set_active_power_profile_mode(mode_index)?;
         }
 
+        // Reset the clocks table in case the settings get reverted back to not having a clocks value configured
+        self.handle.reset_clocks_table().ok();
+
         if config.is_core_clocks_used() {
             let mut table = self.handle.get_clocks_table()?;
 

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -13,7 +13,7 @@ use std::{
     sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
-use tokio::sync::{oneshot, sleep};
+use tokio::{sync::oneshot, time::sleep};
 use tracing::{debug, error, info, trace, warn};
 
 const CONTROLLERS_LOAD_RETRY_ATTEMPTS: u8 = 5;

--- a/lact-daemon/src/server/mod.rs
+++ b/lact-daemon/src/server/mod.rs
@@ -99,10 +99,16 @@ async fn handle_request<'a>(request: Request<'a>, handler: &'a Handler) -> anyho
         Request::SetClocksValue { id, command } => {
             ok_response(handler.set_clocks_value(id, command).await?)
         }
+        Request::BatchSetClocksValue { id, commands } => {
+            ok_response(handler.batch_set_clocks_value(id, commands).await?)
+        }
         Request::SetPowerProfileMode { id, index } => {
             ok_response(handler.set_power_profile_mode(id, index).await?)
         }
         Request::EnableOverdrive => ok_response(system::enable_overdrive()?),
+        Request::ConfirmPendingConfig(command) => {
+            ok_response(handler.confirm_pending_config(command)?)
+        }
     }
 }
 

--- a/lact-schema/src/request.rs
+++ b/lact-schema/src/request.rs
@@ -37,11 +37,23 @@ pub enum Request<'a> {
         id: &'a str,
         command: SetClocksCommand,
     },
+    BatchSetClocksValue {
+        id: &'a str,
+        commands: Vec<SetClocksCommand>,
+    },
     SetPowerProfileMode {
         id: &'a str,
         index: Option<u16>,
     },
     EnableOverdrive,
+    ConfirmPendingConfig(ConfirmCommand),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(tag = "command", rename_all = "snake_case")]
+pub enum ConfirmCommand {
+    Confirm,
+    Revert,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
Implements #164 

The goal of  this PR is to have a confirmation dialog that the user has to click before the settings are saved onto disk. This is useful because when tweaking some settings (especially memory frequency), it's possible to crash your system, and if the settings are saved right away you end up with a soft-bricked system that will apply the broken settings on the next daemon start.