### PR TITLE
fix: inability to add points to an empty fan curve

### DIFF
--- a/lact-gui/src/app/root_stack/thermals_page/fan_curve_frame/mod.rs
+++ b/lact-gui/src/app/root_stack/thermals_page/fan_curve_frame/mod.rs
@@ -26,6 +26,7 @@ impl FanCurveFrame {
         let hbox = Box::new(Orientation::Horizontal, 5);
 
         let curve_container = Frame::new(Some("Fan Curve"));
+        curve_container.set_hexpand(true);
 
         curve_container.set_margin_start(10);
         curve_container.set_margin_end(10);
@@ -94,6 +95,9 @@ impl FanCurveFrame {
         let mut curve = self.get_curve();
         if let Some((temperature, ratio)) = curve.iter().last() {
             curve.insert(temperature + 5, *ratio);
+            self.set_curve(&curve);
+        } else {
+            curve.insert(50, 0.5);
             self.set_curve(&curve);
         }
     }


### PR DESCRIPTION
Fixed a bug where if all points were deleted on the fan curve, it wouldn't be possible to re-add more points. Also fixed a bug when no points were present on the curve it would not expand horizontally.