### PR TITLE
fix: allow gui build without drm

### DIFF
--- a/lact-gui/Cargo.toml
+++ b/lact-gui/Cargo.toml
@@ -10,7 +10,7 @@ gtk-tests = []
 
 [dependencies]
 lact-client = { path = "../lact-client" }
-lact-daemon = { path = "../lact-daemon" }
+lact-daemon = { path = "../lact-daemon", default-features = false }
 gtk = { version = "0.7", package = "gtk4", features = ["v4_6", "blueprint"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
lact-daemon with default features depends on drm, which breaks build without drm.