### PR TITLE
fix: set lactd to run without requiring graphical mode

### DIFF
--- a/res/lactd.service
+++ b/res/lactd.service
@@ -6,4 +6,4 @@ After=multi-user.target
 ExecStart=lact daemon
 
 [Install]
-WantedBy=graphical.target
+WantedBy=multi-user.target


### PR DESCRIPTION
The lact daemon is usable in a command-line environment, since it can be interfaced with via the command line. As it's useful in headless setups, alter the systemd service unit to permit it.