### PR TITLE
chore: add keywords to .dektop file

### DIFF
--- a/res/io.github.lact-linux.desktop
+++ b/res/io.github.lact-linux.desktop
@@ -5,3 +5,4 @@ GenericName=AMDGPU Control Application
 Exec=lact gui
 Icon=io.github.lact-linux
 Categories=System;
+Keywords=AMD;GPU;Radeon;


### PR DESCRIPTION
Adds a keyword section to the `.desktop` file. This allows for searching of the terms, instead of only the application name.