### PR TITLE
feat: close VulkanFeaturesWindow with shortcut

### DIFF
--- a/lact-gui/src/app/root_stack/info_page/vulkan_info/feature_window/mod.rs
+++ b/lact-gui/src/app/root_stack/info_page/vulkan_info/feature_window/mod.rs
@@ -93,6 +93,11 @@ mod imp {
                 }),
             );
 
+            self.search_entry
+                .connect_stop_search(clone!(@weak obj as win => move |_search| {
+                    win.close();
+                }));
+
             self.features_factory.connect_setup(|_, list_item| {
                 let feature = VulkanFeature::default();
                 let row = VulkanFeatureRow::new(feature);

--- a/lact-gui/ui/vulkan_features_window.blp
+++ b/lact-gui/ui/vulkan_features_window.blp
@@ -19,6 +19,15 @@ template $VulkanFeaturesWindow: Window {
       }
     }
   }
+
+  ShortcutController {
+    scope: global;
+
+    Shortcut {
+      trigger: "Escape|<Ctrl>w";
+      action: "action(window.close)";
+    }
+  }
 }
 
 SignalListItemFactory features_factory {}


### PR DESCRIPTION
Allows closing the VulkanFeaturesWindow with `ESC`. Since the search entry has the focus by default, and thus the window cannot receive the `ESC` shortcut, I added a workaround using the `stop_search` signal.