### PR TITLE
feat: display current_gfxclk if available

### DIFF
--- a/lact-daemon/src/server/gpu_controller/mod.rs
+++ b/lact-daemon/src/server/gpu_controller/mod.rs
@@ -239,16 +239,15 @@ impl GpuController {
     }
 
     #[cfg(feature = "libdrm_amdgpu_sys")]
-    fn get_current_gfxclk(&self) -> Option<u64> {
+    fn get_current_gfxclk(&self) -> Option<u16> {
         self.drm_handle
             .as_ref()
             .and_then(|drm_handle| drm_handle.get_gpu_metrics().ok())
             .and_then(|metrics| metrics.get_current_gfxclk())
-            .map(|clk| clk as u64)
     }
 
     #[cfg(not(feature = "libdrm_amdgpu_sys"))]
-    fn get_current_gfxclk(&self) -> Option<u64> {
+    fn get_current_gfxclk(&self) -> Option<u16> {
         None
     }
 

--- a/lact-gui/src/app/root_stack/oc_page/gpu_stats_section.rs
+++ b/lact-gui/src/app/root_stack/oc_page/gpu_stats_section.rs
@@ -29,6 +29,7 @@ impl GpuStatsSection {
 
         let clockspeed = stats.clockspeed;
         self.set_core_clock(format_clockspeed(clockspeed.gpu_clockspeed));
+        self.set_current_core_clock(format_current_gfxclk(clockspeed.current_gfxclk));
         self.set_vram_clock(format_clockspeed(clockspeed.vram_clockspeed));
 
         let voltage = format!("{}V", stats.voltage.gpu.unwrap_or(0) as f64 / 1000f64);
@@ -89,6 +90,8 @@ mod imp {
         #[property(get, set)]
         core_clock: RefCell<String>,
         #[property(get, set)]
+        current_core_clock: RefCell<String>,
+        #[property(get, set)]
         vram_clock: RefCell<String>,
         #[property(get, set)]
         voltage: RefCell<String>,
@@ -129,4 +132,12 @@ mod imp {
 
 fn format_clockspeed(value: Option<u64>) -> String {
     format!("{}MHz", value.unwrap_or(0))
+}
+
+fn format_current_gfxclk(value: Option<u64>) -> String {
+    if let Some(v) = value {
+        format!("{v}MHz")
+    } else {
+        "N/A".to_string()
+    }
 }

--- a/lact-gui/src/app/root_stack/oc_page/gpu_stats_section.rs
+++ b/lact-gui/src/app/root_stack/oc_page/gpu_stats_section.rs
@@ -134,9 +134,15 @@ fn format_clockspeed(value: Option<u64>) -> String {
     format!("{}MHz", value.unwrap_or(0))
 }
 
-fn format_current_gfxclk(value: Option<u64>) -> String {
+fn format_current_gfxclk(value: Option<u16>) -> String {
     if let Some(v) = value {
-        format!("{v}MHz")
+        // if the APU/GPU dose not acually support current_gfxclk,
+        // the value will be `u16::MAX (65535)`
+        if v == u16::MAX {
+            "N/A".to_string()
+        } else {
+            format!("{v}MHz")
+        }
     } else {
         "N/A".to_string()
     }

--- a/lact-gui/ui/oc_page/gpu_stats_section.blp
+++ b/lact-gui/ui/oc_page/gpu_stats_section.blp
@@ -36,12 +36,12 @@ template $GpuStatsSection: $PageSection {
             spacing: 5;
 
             $InfoRow {
-                name: "GPU Core Clock:";
+                name: "GPU Core Clock (Average):";
                 value: bind template.core-clock;
             }
 
             $InfoRow {
-                name: "GPU Core Clock (Current):";
+                name: "GPU Core Clock (Target):";
                 value: bind template.current-core-clock;
             }
 

--- a/lact-gui/ui/oc_page/gpu_stats_section.blp
+++ b/lact-gui/ui/oc_page/gpu_stats_section.blp
@@ -41,6 +41,11 @@ template $GpuStatsSection: $PageSection {
             }
 
             $InfoRow {
+                name: "GPU Core Clock (Current):";
+                value: bind template.current-core-clock;
+            }
+
+            $InfoRow {
                 name: "GPU Voltage:";
                 value: bind template.voltage;
             }

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -208,6 +208,7 @@ pub struct PmfwInfo {
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct ClockspeedStats {
     pub gpu_clockspeed: Option<u64>,
+    pub current_gfxclk: Option<u64>,
     pub vram_clockspeed: Option<u64>,
 }
 

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -208,7 +208,7 @@ pub struct PmfwInfo {
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct ClockspeedStats {
     pub gpu_clockspeed: Option<u64>,
-    pub current_gfxclk: Option<u64>,
+    pub current_gfxclk: Option<u16>,
     pub vram_clockspeed: Option<u64>,
 }
 


### PR DESCRIPTION
Some AMD APUs/GPUs has the Average Clock and the Current Clock, the AMDGPU driver reports the Average Clock in `AMDGPU_INFO_SENSOR_GFX_SCLK` and hwmon.  
This PR gets the Current clock from `gpu_metrics` and displays it.

ref: https://gitlab.freedesktop.org/drm/amd/-/issues/2747

![Screenshot_20240122_014943](https://github.com/ilya-zlobintsev/LACT/assets/53935716/5ceb0047-9acf-4472-8b9e-b77db0aede43)
