### PR TITLE
LACT OpenRC support

### DIFF
--- a/res/lact-daemon-openrc
+++ b/res/lact-daemon-openrc
@@ -7,7 +7,7 @@
 # # rc-service lact-daemon-openrc start
 
 supervisor=supervise-daemon
-command="/usr/bin/lact"
+command="lact"
 command_args="daemon"
 
 depend() {

--- a/res/lact-daemon-openrc
+++ b/res/lact-daemon-openrc
@@ -1,0 +1,23 @@
+#!/usr/bin/openrc-run
+
+# This service allows running LACT with Artix Linux OpenRC.
+# Place it under /etc/init.d and make it executable.
+# Run
+# # rc-update add lact-daemon-openrc 
+# # rc-service lact-daemon-openrc start
+
+supervisor=supervise-daemon
+command="/usr/bin/lact"
+command_args="daemon"
+
+depend() {
+    need localmount
+
+    after bootmisc consolefont modules netmount
+    after ypbind autofs openvpn gpm lircmd
+    after quota keymaps
+    before alsasound
+    want logind
+
+    provide lactd lact-daemon
+}


### PR DESCRIPTION
LACT daemon can work standalone on non-systemd distribution.

This is the example of service that is run in init environment similar to what is required for `sddm` / `gdm` which usually start the desktop session. It is possible to remove some of dependencies in case different configuration is required.
