### PR TITLE
fix: avoid selectable labels for dynamic info

### DIFF
--- a/lact-gui/src/app/info_row.rs
+++ b/lact-gui/src/app/info_row.rs
@@ -37,6 +37,8 @@ mod imp {
         name: RefCell<String>,
         #[property(get, set)]
         value: RefCell<String>,
+        #[property(get, set)]
+        selectable: RefCell<bool>,
 
         #[template_child]
         value_label: TemplateChild<Label>,

--- a/lact-gui/ui/info_row.blp
+++ b/lact-gui/ui/info_row.blp
@@ -14,7 +14,7 @@ template $InfoRow: Box {
     Label value_label {
         label: bind template.value;
         halign: end;
-        selectable: true;
+        selectable: bind template.selectable;
         use-markup: true;
     }
 }

--- a/lact-gui/ui/software_page.blp
+++ b/lact-gui/ui/software_page.blp
@@ -11,15 +11,18 @@ template $SoftwarePage: Box {
     $InfoRow {
         name: "LACT Daemon:";
         value: bind template.daemon_version;
+        selectable: true;
     }
 
     $InfoRow {
         name: "LACT GUI:";
         value: bind template.gui_version;
+        selectable: true;
     }
 
     $InfoRow {
         name: "Kernel Version:";
         value: bind template.kernel_version;
+        selectable: true;
     }
 }


### PR DESCRIPTION
Make InfoRow labels not selectable by default. Allow an override of the attribute in the template (for Software tab for example).

Motivation:
GTK will place the blinking cursor on the first selectable label of a view/tab. Placing the cursor on dynamic info like the current GPU Core Clock will show the cursor jumping around as the number of digits change a lot (best seen in the OC tab).

As the selection of a label is discarded on update of a label (which happens multiple times a second for a lot of the OC and Thermals values) the cursor acts as a visual distraction rather than a feature.

Demonstration of the issue:
![Peek 2024-02-22 20-01](https://github.com/ilya-zlobintsev/LACT/assets/520251/8d674073-e03e-4414-a3e6-b0e6270da301)