### PR TITLE
feat: fan control hysteresis

### DIFF
--- a/lact-client/src/lib.rs
+++ b/lact-client/src/lib.rs
@@ -10,8 +10,8 @@ use anyhow::{anyhow, Context};
 use nix::unistd::getuid;
 use schema::{
     request::{ConfirmCommand, SetClocksCommand},
-    ClocksInfo, DeviceInfo, DeviceListEntry, DeviceStats, FanControlMode, FanCurveMap, PmfwOptions,
-    PowerStates, Request, Response, SystemInfo,
+    ClocksInfo, DeviceInfo, DeviceListEntry, DeviceStats, FanOptions, PowerStates, Request,
+    Response, SystemInfo,
 };
 use serde::Deserialize;
 use std::{
@@ -104,24 +104,8 @@ impl DaemonClient {
         self.make_request(Request::ListDevices)
     }
 
-    pub fn set_fan_control(
-        &self,
-        id: &str,
-        enabled: bool,
-        mode: Option<FanControlMode>,
-        static_speed: Option<f64>,
-        curve: Option<FanCurveMap>,
-        pmfw: PmfwOptions,
-    ) -> anyhow::Result<u64> {
-        self.make_request(Request::SetFanControl {
-            id,
-            enabled,
-            mode,
-            static_speed,
-            curve,
-            pmfw,
-        })?
-        .inner()
+    pub fn set_fan_control(&self, cmd: FanOptions) -> anyhow::Result<u64> {
+        self.make_request(Request::SetFanControl(cmd))?.inner()
     }
 
     pub fn set_power_cap(&self, id: &str, cap: Option<f64>) -> anyhow::Result<u64> {

--- a/lact-daemon/src/config.rs
+++ b/lact-daemon/src/config.rs
@@ -109,6 +109,7 @@ pub struct FanControlSettings {
     pub temperature_key: String,
     pub interval_ms: u64,
     pub curve: FanCurve,
+    pub spindown_delay_ms: Option<u64>,
 }
 
 impl Default for FanControlSettings {
@@ -119,6 +120,7 @@ impl Default for FanControlSettings {
             temperature_key: "edge".to_owned(),
             interval_ms: 500,
             curve: FanCurve(default_fan_curve()),
+            spindown_delay_ms: None,
         }
     }
 }
@@ -248,6 +250,7 @@ mod tests {
                         interval_ms: 500,
                         mode: FanControlMode::Curve,
                         static_speed: 0.5,
+                        spindown_delay_ms: None,
                     }),
                     ..Default::default()
                 },

--- a/lact-daemon/src/config.rs
+++ b/lact-daemon/src/config.rs
@@ -110,6 +110,7 @@ pub struct FanControlSettings {
     pub interval_ms: u64,
     pub curve: FanCurve,
     pub spindown_delay_ms: Option<u64>,
+    pub change_threshold: Option<u64>,
 }
 
 impl Default for FanControlSettings {
@@ -121,6 +122,7 @@ impl Default for FanControlSettings {
             interval_ms: 500,
             curve: FanCurve(default_fan_curve()),
             spindown_delay_ms: None,
+            change_threshold: None,
         }
     }
 }
@@ -230,11 +232,10 @@ fn default_apply_settings_timer() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use lact_schema::{FanControlMode, PmfwOptions};
-    use std::collections::HashMap;
-
     use super::{ClocksConfiguration, Config, Daemon, FanControlSettings, Gpu};
     use crate::server::gpu_controller::fan_control::FanCurve;
+    use lact_schema::{FanControlMode, PmfwOptions};
+    use std::collections::HashMap;
 
     #[test]
     fn serde_de_full() {
@@ -250,7 +251,8 @@ mod tests {
                         interval_ms: 500,
                         mode: FanControlMode::Curve,
                         static_speed: 0.5,
-                        spindown_delay_ms: None,
+                        spindown_delay_ms: Some(5000),
+                        change_threshold: Some(3),
                     }),
                     ..Default::default()
                 },

--- a/lact-daemon/src/server/mod.rs
+++ b/lact-daemon/src/server/mod.rs
@@ -86,18 +86,7 @@ async fn handle_request<'a>(request: Request<'a>, handler: &'a Handler) -> anyho
         Request::DevicePowerProfileModes { id } => {
             ok_response(handler.get_power_profile_modes(id)?)
         }
-        Request::SetFanControl {
-            id,
-            enabled,
-            mode,
-            static_speed,
-            curve,
-            pmfw,
-        } => ok_response(
-            handler
-                .set_fan_control(id, enabled, mode, static_speed, curve, pmfw)
-                .await?,
-        ),
+        Request::SetFanControl(opts) => ok_response(handler.set_fan_control(opts).await?),
         Request::ResetPmfw { id } => ok_response(handler.reset_pmfw(id).await?),
         Request::SetPowerCap { id, cap } => ok_response(handler.set_power_cap(id, cap).await?),
         Request::SetPerformanceLevel {

--- a/lact-daemon/src/server/mod.rs
+++ b/lact-daemon/src/server/mod.rs
@@ -12,7 +12,7 @@ use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     net::{UnixListener, UnixStream},
 };
-use tracing::{debug, error, instrument};
+use tracing::{error, instrument, trace};
 
 pub struct Server {
     pub handler: Handler,
@@ -52,7 +52,7 @@ pub async fn handle_stream(stream: UnixStream, handler: Handler) -> anyhow::Resu
 
     let mut buf = String::new();
     while stream.read_line(&mut buf).await? != 0 {
-        debug!("handling request: {}", buf.trim_end());
+        trace!("handling request: {}", buf.trim_end());
 
         let maybe_request = serde_json::from_str(&buf);
         let response = match maybe_request {
@@ -127,7 +127,7 @@ async fn handle_request<'a>(request: Request<'a>, handler: &'a Handler) -> anyho
 }
 
 fn ok_response<T: Serialize + Debug>(data: T) -> anyhow::Result<Vec<u8>> {
-    debug!("responding with {data:?}");
+    trace!("responding with {data:?}");
     Ok(serde_json::to_vec(&Response::Ok(data))?)
 }
 

--- a/lact-gui/src/app/mod.rs
+++ b/lact-gui/src/app/mod.rs
@@ -13,7 +13,7 @@ use gtk::glib::{timeout_future, ControlFlow};
 use gtk::{gio::ApplicationFlags, prelude::*, *};
 use header::Header;
 use lact_client::schema::request::{ConfirmCommand, SetClocksCommand};
-use lact_client::schema::GIT_COMMIT;
+use lact_client::schema::{FanOptions, GIT_COMMIT};
 use lact_client::DaemonClient;
 use lact_daemon::MODULE_CONF_PATH;
 use root_stack::RootStack;
@@ -408,16 +408,19 @@ impl App {
 
         if let Some(thermals_settings) = self.root_stack.thermals_page.get_thermals_settings() {
             debug!("applying thermal settings: {thermals_settings:?}");
+            let opts = FanOptions {
+                id: &gpu_id,
+                enabled: thermals_settings.manual_fan_control,
+                mode: thermals_settings.mode,
+                static_speed: thermals_settings.static_speed,
+                curve: thermals_settings.curve,
+                pmfw: thermals_settings.pmfw,
+                spindown_delay_ms: thermals_settings.spindown_delay_ms,
+                change_threshold: thermals_settings.change_threshold,
+            };
 
             self.daemon_client
-                .set_fan_control(
-                    &gpu_id,
-                    thermals_settings.manual_fan_control,
-                    thermals_settings.mode,
-                    thermals_settings.static_speed,
-                    thermals_settings.curve,
-                    thermals_settings.pmfw,
-                )
+                .set_fan_control(opts)
                 .context("Could not set fan control")?;
             self.daemon_client
                 .confirm_pending_config(ConfirmCommand::Confirm)

--- a/lact-gui/src/app/root_stack/thermals_page/fan_curve_frame/mod.rs
+++ b/lact-gui/src/app/root_stack/thermals_page/fan_curve_frame/mod.rs
@@ -224,16 +224,12 @@ impl FanCurveFrame {
             .set_initial_value(value.unwrap_or(0) as f64);
     }
 
-    pub fn get_change_threshold(&self) -> Option<u64> {
-        self.change_threshold_adj
-            .get_changed_value(false)
-            .map(|value| value as u64)
+    pub fn get_change_threshold(&self) -> u64 {
+        self.change_threshold_adj.value() as u64
     }
 
-    pub fn get_spindown_delay_ms(&self) -> Option<u64> {
-        self.spindown_delay_adj
-            .get_changed_value(false)
-            .map(|value| value as u64)
+    pub fn get_spindown_delay_ms(&self) -> u64 {
+        self.spindown_delay_adj.value() as u64
     }
 
     pub fn set_hysteresis_settings_visibile(&self, visible: bool) {

--- a/lact-gui/src/app/root_stack/thermals_page/mod.rs
+++ b/lact-gui/src/app/root_stack/thermals_page/mod.rs
@@ -257,8 +257,8 @@ impl ThermalsPage {
                 static_speed,
                 curve,
                 pmfw,
-                change_threshold: self.fan_curve_frame.get_change_threshold(),
-                spindown_delay_ms: self.fan_curve_frame.get_spindown_delay_ms(),
+                change_threshold: Some(self.fan_curve_frame.get_change_threshold()),
+                spindown_delay_ms: Some(self.fan_curve_frame.get_spindown_delay_ms()),
             })
         } else {
             None

--- a/lact-gui/src/app/root_stack/thermals_page/mod.rs
+++ b/lact-gui/src/app/root_stack/thermals_page/mod.rs
@@ -5,7 +5,7 @@ use glib::clone;
 use gtk::prelude::*;
 use gtk::*;
 use lact_client::schema::{
-    default_fan_curve, DeviceInfo, DeviceStats, FanControlMode, FanCurveMap, PmfwOptions,
+    default_fan_curve, DeviceInfo, DeviceStats, FanControlMode, FanCurveMap, PmfwInfo, PmfwOptions,
     SystemInfo,
 };
 use lact_daemon::AMDGPU_FAMILY_GC_11_0_0;
@@ -25,6 +25,8 @@ pub struct ThermalsSettings {
     pub static_speed: Option<f64>,
     pub curve: Option<FanCurveMap>,
     pub pmfw: PmfwOptions,
+    pub spindown_delay_ms: Option<u64>,
+    pub change_threshold: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -195,6 +197,15 @@ impl ThermalsPage {
                 self.fan_curve_frame.set_curve(curve);
             }
 
+            self.fan_curve_frame
+                .set_spindown_delay_ms(stats.fan.spindown_delay_ms);
+            self.fan_curve_frame
+                .set_change_threshold(stats.fan.change_threshold);
+
+            // Only show hysteresis settings when PMFW is not used
+            self.fan_curve_frame
+                .set_hysteresis_settings_visibile(stats.fan.pmfw_info == PmfwInfo::default());
+
             if !stats.fan.control_enabled && self.fan_curve_frame.get_curve().is_empty() {
                 self.fan_curve_frame.set_curve(&default_fan_curve());
             }
@@ -246,6 +257,8 @@ impl ThermalsPage {
                 static_speed,
                 curve,
                 pmfw,
+                change_threshold: self.fan_curve_frame.get_change_threshold(),
+                spindown_delay_ms: self.fan_curve_frame.get_spindown_delay_ms(),
             })
         } else {
             None

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -197,6 +197,8 @@ pub struct FanStats {
     pub speed_current: Option<u32>,
     pub speed_max: Option<u32>,
     pub speed_min: Option<u32>,
+    pub spindown_delay_ms: Option<u64>,
+    pub change_threshold: Option<u64>,
     // RDNA3+ params
     #[serde(default)]
     pub pmfw_info: PmfwInfo,
@@ -272,4 +274,18 @@ pub struct PmfwOptions {
     pub acoustic_target: Option<u32>,
     pub minimum_pwm: Option<u32>,
     pub target_temperature: Option<u32>,
+}
+
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct FanOptions<'a> {
+    pub id: &'a str,
+    pub enabled: bool,
+    pub mode: Option<FanControlMode>,
+    pub static_speed: Option<f64>,
+    pub curve: Option<FanCurveMap>,
+    #[serde(default)]
+    pub pmfw: PmfwOptions,
+    pub spindown_delay_ms: Option<u64>,
+    pub change_threshold: Option<u64>,
 }

--- a/lact-schema/src/request.rs
+++ b/lact-schema/src/request.rs
@@ -1,4 +1,4 @@
-use crate::{FanControlMode, FanCurveMap, PmfwOptions};
+use crate::FanOptions;
 use amdgpu_sysfs::gpu_handle::{PerformanceLevel, PowerLevelKind};
 use serde::{Deserialize, Serialize};
 
@@ -20,15 +20,7 @@ pub enum Request<'a> {
     DevicePowerProfileModes {
         id: &'a str,
     },
-    SetFanControl {
-        id: &'a str,
-        enabled: bool,
-        mode: Option<FanControlMode>,
-        static_speed: Option<f64>,
-        curve: Option<FanCurveMap>,
-        #[serde(default)]
-        pmfw: PmfwOptions,
-    },
+    SetFanControl(FanOptions<'a>),
     ResetPmfw {
         id: &'a str,
     },

--- a/lact-schema/src/tests.rs
+++ b/lact-schema/src/tests.rs
@@ -1,6 +1,7 @@
-use crate::{Pong, Request, Response};
+use crate::{FanControlMode, FanOptions, PmfwOptions, Pong, Request, Response};
 use anyhow::anyhow;
 use serde_json::json;
+use std::collections::BTreeMap;
 
 #[test]
 fn ping_requset() {
@@ -56,4 +57,32 @@ fn error_response() {
     let response = Response::<()>::from(error);
 
     assert_eq!(serde_json::to_value(response).unwrap(), expected_response);
+}
+
+#[test]
+fn set_fan_clocks() {
+    let value = r#"{
+        "command": "set_fan_control",
+        "args": {
+            "id": "123",
+            "enabled": true,
+            "mode": "curve",
+            "curve": {
+                "30": 30.0,
+                "50": 50.0
+            }
+        }
+    }"#;
+    let request: Request = serde_json::from_str(value).unwrap();
+    let expected_request = Request::SetFanControl(FanOptions {
+        id: "123",
+        enabled: true,
+        mode: Some(FanControlMode::Curve),
+        static_speed: None,
+        curve: Some(BTreeMap::from([(30, 30.0), (50, 50.0)])),
+        pmfw: PmfwOptions::default(),
+        spindown_delay_ms: None,
+        change_threshold: None,
+    });
+    assert_eq!(expected_request, request);
 }


### PR DESCRIPTION
https://github.com/ilya-zlobintsev/LACT/issues/291

This PR adds 2 new options to fan control with a custom curve (only for RDNA2 and older, this is not exposed via PMFW on RDNA3):
- Spindown delay - when a temperature (and the calculated fan speed) is lower than the previous reading, delay actually changing the fan speed for the specified duration, and re-check if it is still needed after it.
- Speed change threshold - changes in temperature lower than this value will not affect the fan speed. This is helpful to avoid needlessly changing the PWM value for 1-2 degree changes.