### PR TITLE
fix: fix press 'Enable Overclocking' will panic

### DIFF
--- a/lact-gui/src/app/mod.rs
+++ b/lact-gui/src/app/mod.rs
@@ -762,8 +762,10 @@ impl App {
             .transient_for(&self.window)
             .build();
 
-        dialog.titlebar().unwrap().set_margin_start(15);
-        dialog.titlebar().unwrap().set_margin_end(15);
+        if let Some(bar) = dialog.titlebar() {
+            bar.set_margin_start(15);
+            bar.set_margin_end(15);
+        }
 
         dialog
     }


### PR DESCRIPTION
Lact v0.5.4 and master press 'Enable Overclocking' button will panic, output:

```
thread 'main' panicked at lact-gui/src/app/mod.rs:765:27:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This commit fixes this issue:

![图片](https://github.com/ilya-zlobintsev/LACT/assets/19554922/7a62d67c-ebdb-431d-a642-bbefb97bf1db)
