### PR TITLE
feat: show detailed power profile information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "amdgpu-sysfs"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b277cf650bff281b49b12f4a2a4a004485e0b3ecfd34961c5f9b258800ea09"
+checksum = "cd30ccf0f663fbe9465c7819c0f52cfcb9bf890c7445192f23ff381fad0b3204"
 dependencies = [
  "enum_dispatch",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.dependencies]
-amdgpu-sysfs = { version = "0.15.0", features = ["serde"] }
+amdgpu-sysfs = { version = "0.16.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "3.5.0", default-features = false, features = [
     "macros",

--- a/lact-gui/src/app/root_stack/oc_page/mod.rs
+++ b/lact-gui/src/app/root_stack/oc_page/mod.rs
@@ -2,7 +2,7 @@ mod clocks_frame;
 mod gpu_stats_section;
 mod performance_frame;
 mod power_cap_section;
-// mod power_cap_frame;
+mod power_profile;
 mod power_states;
 
 use self::power_cap_section::PowerCapSection;

--- a/lact-gui/src/app/root_stack/oc_page/power_profile/mod.rs
+++ b/lact-gui/src/app/root_stack/oc_page/power_profile/mod.rs
@@ -1,0 +1,1 @@
+pub mod power_profile_component_grid;

--- a/lact-gui/src/app/root_stack/oc_page/power_profile/power_profile_component_grid.rs
+++ b/lact-gui/src/app/root_stack/oc_page/power_profile/power_profile_component_grid.rs
@@ -1,0 +1,90 @@
+use amdgpu_sysfs::gpu_handle::power_profile_mode::{PowerProfileComponent, PowerProfileModesTable};
+use gtk::{
+    glib::{self, Object},
+    prelude::GridExt,
+    prelude::WidgetExt,
+    Label,
+};
+
+glib::wrapper! {
+    pub struct PowerProfileComponentGrid(ObjectSubclass<imp::PowerProfileComponentGrid>)
+        @extends gtk::Grid,
+        @implements gtk::Accessible, gtk::Buildable, gtk::Widget;
+}
+
+impl PowerProfileComponentGrid {
+    pub fn new() -> Self {
+        Object::builder()
+            .property("margin-start", 5)
+            .property("margin-end", 5)
+            .property("margin-top", 5)
+            .property("margin-bottom", 5)
+            .build()
+    }
+
+    pub fn set_component(&self, component: &PowerProfileComponent, table: &PowerProfileModesTable) {
+        while let Some(child) = self.first_child() {
+            self.remove(&child);
+        }
+
+        for (i, value) in component.values.iter().enumerate() {
+            let name = &table.value_names[i];
+
+            let name_label = Label::builder()
+                .label(&format!("{name}:"))
+                .hexpand(true)
+                .halign(gtk::Align::Start)
+                .build();
+
+            self.attach(&name_label, 0, i as i32, 1, 1);
+
+            let mut value_label_builder = Label::builder().halign(gtk::Align::End);
+            value_label_builder = match value {
+                Some(value) => value_label_builder.label(value.to_string()),
+                None => value_label_builder.label("Not set"),
+            };
+            self.attach(&value_label_builder.build(), 1, i as i32, 1, 1);
+        }
+    }
+}
+
+impl Default for PowerProfileComponentGrid {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+mod imp {
+    use gtk::{
+        glib::{self, subclass::InitializingObject},
+        subclass::{
+            prelude::*,
+            widget::{CompositeTemplateClass, WidgetImpl},
+        },
+        CompositeTemplate,
+    };
+
+    #[derive(CompositeTemplate, Default)]
+    #[template(file = "ui/oc_page/power_profile/power_profile_component_grid.blp")]
+    pub struct PowerProfileComponentGrid {}
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for PowerProfileComponentGrid {
+        const NAME: &'static str = "PowerProfileComponentGrid";
+        type Type = super::PowerProfileComponentGrid;
+        type ParentType = gtk::Grid;
+
+        fn class_init(class: &mut Self::Class) {
+            class.bind_template();
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for PowerProfileComponentGrid {}
+
+    impl WidgetImpl for PowerProfileComponentGrid {}
+    impl GridImpl for PowerProfileComponentGrid {}
+}

--- a/lact-gui/ui/oc_page/power_profile/power_profile_component_grid.blp
+++ b/lact-gui/ui/oc_page/power_profile/power_profile_component_grid.blp
@@ -1,0 +1,6 @@
+using Gtk 4.0;
+
+template $PowerProfileComponentGrid: Grid {
+    row-spacing: 5;
+    column-spacing: 5;
+}


### PR DESCRIPTION
Shows detailed value info from the current power profile. First part of #328, the values are parsed but are not editable for now.

Looks like this on RDNA2 (detailed power profile format):
![image](https://github.com/user-attachments/assets/4b314c2c-a487-4e03-bdf9-788f4daf95f5)


And like this on Pre-RDNA (simple power profile format):
![image](https://github.com/user-attachments/assets/ece689f4-c7d9-48d9-92b4-7f4b15cc0929)
