### PR TITLE
feat: show effective VRAM clockspeed in the GUI on GDDR6 

### DIFF
--- a/lact-daemon/src/server/gpu_controller/mod.rs
+++ b/lact-daemon/src/server/gpu_controller/mod.rs
@@ -189,6 +189,8 @@ impl GpuController {
 
     #[cfg(feature = "libdrm_amdgpu_sys")]
     fn get_drm_info(&self) -> Option<DrmInfo> {
+        use libdrm_amdgpu_sys::AMDGPU::VRAM_TYPE;
+
         trace!("Reading DRM info");
         let drm_handle = self.drm_handle.as_ref();
 
@@ -211,6 +213,10 @@ impl GpuController {
                 chip_class: drm_info.get_chip_class().to_string(),
                 compute_units: drm_info.cu_active_number,
                 vram_type: drm_info.get_vram_type().to_string(),
+                vram_clock_ratio: match drm_info.get_vram_type() {
+                    VRAM_TYPE::GDDR6 => 2.0,
+                    _ => 1.0,
+                },
                 vram_bit_width: drm_info.vram_bit_width,
                 vram_max_bw: drm_info.peak_memory_bw_gb().to_string(),
                 l1_cache_per_cu: drm_info.get_l1_cache_size(),

--- a/lact-gui/src/app/mod.rs
+++ b/lact-gui/src/app/mod.rs
@@ -361,6 +361,14 @@ impl App {
         trace!("setting info {info:?}");
 
         self.root_stack.info_page.set_info(&info);
+        self.root_stack.oc_page.set_info(&info);
+
+        let vram_clock_ratio = info
+            .drm_info
+            .as_ref()
+            .map(|info| info.vram_clock_ratio)
+            .unwrap_or(1.0);
+        self.graphs_window.set_vram_clock_ratio(vram_clock_ratio);
 
         self.set_initial(gpu_id);
         self.root_stack.thermals_page.set_info(&info);

--- a/lact-gui/src/app/root_stack/oc_page/clocks_frame.rs
+++ b/lact-gui/src/app/root_stack/oc_page/clocks_frame.rs
@@ -296,6 +296,11 @@ impl ClocksFrame {
         self.clocks_data_unavailable_label.show();
     }
 
+    pub fn set_vram_clock_ratio(&self, ratio: f64) {
+        self.min_mclk_adjustment.set_value_ratio(ratio);
+        self.max_mclk_adjustment.set_value_ratio(ratio);
+    }
+
     pub fn connect_clocks_changed<F: Fn() + 'static + Clone>(&self, f: F) {
         let f = clone!(
             #[strong]

--- a/lact-gui/src/app/root_stack/oc_page/clocks_frame/adjustment_row.rs
+++ b/lact-gui/src/app/root_stack/oc_page/clocks_frame/adjustment_row.rs
@@ -1,0 +1,122 @@
+use gtk::{
+    glib::{self, Object},
+    prelude::WidgetExt,
+    prelude::{GridExt, ObjectExt},
+    subclass::prelude::ObjectSubclassIsExt,
+    Grid,
+};
+use std::sync::atomic::Ordering;
+
+glib::wrapper! {
+    pub struct AdjustmentRow(ObjectSubclass<imp::AdjustmentRow>)
+        @extends gtk::Widget,
+        @implements gtk::Orientable, gtk::Accessible, gtk::Buildable;
+}
+
+impl AdjustmentRow {
+    pub fn new(title: &str) -> Self {
+        Object::builder()
+            .property("title", title)
+            .property("visible", true)
+            .build()
+    }
+
+    pub fn new_and_attach(title: &str, grid: &Grid, row: i32) -> Self {
+        let adj_row = Self::new(title);
+        adj_row.attach_to_grid(grid, row);
+        adj_row
+    }
+
+    pub fn get_value(&self) -> Option<i32> {
+        self.imp()
+            .adjustment
+            .get_changed_value(false)
+            .map(|value| value as i32)
+    }
+
+    pub fn attach_to_grid(&self, grid: &Grid, row: i32) {
+        let obj = self.imp();
+
+        obj.label.unparent();
+        obj.scale.unparent();
+        obj.value_button.unparent();
+
+        grid.attach(&obj.label.get(), 0, row, 1, 1);
+        grid.attach(&obj.scale.get(), 1, row, 4, 1);
+        grid.attach(&obj.value_button.get(), 6, row, 4, 1);
+    }
+
+    pub fn refresh(&self) {
+        let obj = self.imp();
+        obj.adjustment.emit_by_name::<()>("value-changed", &[]);
+        self.notify("visible");
+        obj.adjustment.imp().changed.store(false, Ordering::SeqCst);
+    }
+}
+
+mod imp {
+    use crate::app::root_stack::oc_adjustment::OcAdjustment;
+    use glib::{clone, subclass::InitializingObject};
+    use gtk::{
+        glib::{self, Properties},
+        prelude::*,
+        subclass::{
+            prelude::*,
+            widget::{CompositeTemplateClass, WidgetImpl},
+        },
+        CompositeTemplate, Label, MenuButton, Scale, TemplateChild,
+    };
+    use std::cell::{Cell, RefCell};
+
+    #[derive(CompositeTemplate, Default, Properties)]
+    #[properties(wrapper_type = super::AdjustmentRow)]
+    #[template(file = "ui/oc_page/clocks_frame/adjustment_row.blp")]
+    pub struct AdjustmentRow {
+        #[property(get, set)]
+        pub visible: Cell<bool>,
+        #[property(get, set)]
+        pub title: RefCell<String>,
+
+        #[template_child]
+        pub label: TemplateChild<Label>,
+        #[template_child]
+        pub scale: TemplateChild<Scale>,
+        #[template_child]
+        pub value_button: TemplateChild<MenuButton>,
+        #[template_child]
+        pub adjustment: TemplateChild<OcAdjustment>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for AdjustmentRow {
+        const NAME: &'static str = "AdjustmentRow";
+        type Type = super::AdjustmentRow;
+        type ParentType = gtk::Widget;
+
+        fn class_init(class: &mut Self::Class) {
+            OcAdjustment::ensure_type();
+            class.bind_template();
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for AdjustmentRow {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            self.adjustment.connect_value_changed(clone!(
+                #[strong(rename_to = value_button)]
+                self.value_button,
+                move |adj| {
+                    value_button.set_label(&adj.value().to_string());
+                }
+            ));
+        }
+    }
+
+    impl WidgetImpl for AdjustmentRow {}
+}

--- a/lact-gui/src/app/root_stack/oc_page/mod.rs
+++ b/lact-gui/src/app/root_stack/oc_page/mod.rs
@@ -12,7 +12,7 @@ use clocks_frame::ClocksFrame;
 use gpu_stats_section::GpuStatsSection;
 use gtk::*;
 use gtk::{glib::clone, prelude::*};
-use lact_client::schema::{DeviceStats, SystemInfo};
+use lact_client::schema::{DeviceInfo, DeviceStats, SystemInfo};
 use performance_frame::PerformanceFrame;
 // use power_cap_frame::PowerCapFrame;
 use std::collections::HashMap;
@@ -111,6 +111,17 @@ impl OcPage {
 
             self.set_performance_level(stats.performance_level);
         }
+    }
+
+    pub fn set_info(&self, info: &DeviceInfo) {
+        let vram_clock_ratio = info
+            .drm_info
+            .as_ref()
+            .map(|info| info.vram_clock_ratio)
+            .unwrap_or(1.0);
+
+        self.stats_section.set_vram_clock_ratio(vram_clock_ratio);
+        self.clocks_frame.set_vram_clock_ratio(vram_clock_ratio);
     }
 
     pub fn set_clocks_table(&self, table: Option<ClocksTableGen>) {

--- a/lact-gui/ui/oc_page/clocks_frame/adjustment_row.blp
+++ b/lact-gui/ui/oc_page/clocks_frame/adjustment_row.blp
@@ -1,0 +1,37 @@
+using Gtk 4.0;
+
+template $AdjustmentRow: Widget {
+    Label label {
+        label: bind template.title;
+        visible: bind template.visible;
+        halign: start;
+    }
+
+    Scale scale {
+        adjustment: adjustment;
+        orientation: horizontal;
+        hexpand: true;
+        digits: 0;
+        round-digits: 0;
+        value-pos: right;
+        margin-start: 5;
+        margin-end: 5;
+        visible: bind template.visible;
+    }
+
+    MenuButton value_button {
+        popover: Popover {
+            child: SpinButton {
+                adjustment: adjustment;
+            };
+        };
+
+        direction: none;
+        visible: bind template.visible;
+    }
+}
+
+$OcAdjustment adjustment {
+    step-increment: 1;
+    page-increment: 10;
+}

--- a/lact-gui/ui/oc_page/clocks_frame/adjustment_row.blp
+++ b/lact-gui/ui/oc_page/clocks_frame/adjustment_row.blp
@@ -21,7 +21,7 @@ template $AdjustmentRow: Widget {
 
     MenuButton value_button {
         popover: Popover {
-            child: SpinButton {
+            child: SpinButton value_spinbutton {
                 adjustment: adjustment;
             };
         };

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -100,6 +100,7 @@ pub struct DrmInfo {
     pub chip_class: String,
     pub compute_units: u32,
     pub vram_type: String,
+    pub vram_clock_ratio: f64,
     pub vram_bit_width: u32,
     pub vram_max_bw: String,
     pub l1_cache_per_cu: u32,


### PR DESCRIPTION
Resolves confusion in #363 

This only changes how the values are shown in the UI, the daemon (including config file) still operates with physical values.