### PR TITLE
Set codegen-units=1 to decrease binary size in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ indexmap = { version = "2.5.0", features = ["serde"] }
 
 [profile.release]
 strip = "symbols"
+codegen-units = 1
 opt-level = "s"
 lto = true
 


### PR DESCRIPTION
Before
```
❯ ls -lah target/release/lact         
-rwxr-xr-x 2 codemonkey codemonkey 6.9M Oct 22 18:45 target/release/lact
```

After
```
❯ ls -lah target/release/lact
-rwxr-xr-x 2 codemonkey codemonkey 6.4M Oct 22 18:46 target/release/lact
```