### PR TITLE
make throttling flags ellipsized to avoid massively oversized window

### DIFF
--- a/lact-gui/ui/info_row.blp
+++ b/lact-gui/ui/info_row.blp
@@ -30,5 +30,6 @@ template $InfoRow: Box {
         halign: end;
         selectable: bind template.selectable;
         use-markup: true;
+        ellipsize: end;
     }
 }


### PR DESCRIPTION
Small change to stop chips with every single throttling flag enabled from causing a comically-oversized >20k pixel wide window to spawn:

<img width="2011" alt="Screenshot 2024-11-07 at 12 37 40 am" src="https://github.com/user-attachments/assets/ae40fa1c-d82d-4fdb-823c-da32d011c2df">

We simply tell GTK to ellipsize the text if it won't fit. This could probably use a little bit of margin on the left (it runs into the `Throttling:` label a tad) but it does the job, and there aren't many systems this affects.