### PR TITLE
feat: add AMD BC-250 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,8 +54,7 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "amdgpu-sysfs"
 version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01631a1d520df9737660f26b0c64c5ea9d74667bf4cbb1c1559a6ddb8478c4ef"
+source = "git+https://github.com/ilya-zlobintsev/amdgpu-sysfs-rs?branch=bc-250#9eb7b2ebca00dd4b5ea54a397c51f922c45dda90"
 dependencies = [
  "enum_dispatch",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "amdgpu-sysfs"
 version = "0.17.2"
-source = "git+https://github.com/ilya-zlobintsev/amdgpu-sysfs-rs?branch=bc-250#9eb7b2ebca00dd4b5ea54a397c51f922c45dda90"
+source = "git+https://github.com/ilya-zlobintsev/amdgpu-sysfs-rs?branch=bc-250#3ef1a281d7448e5cae3fcabdeec8d9f4a80acf07"
 dependencies = [
  "enum_dispatch",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ members = [
 ]
 
 [workspace.dependencies]
-amdgpu-sysfs = { version = "0.17.0", features = ["serde"] }
+amdgpu-sysfs = { git = "https://github.com/ilya-zlobintsev/amdgpu-sysfs-rs", branch = "bc-250", features = [
+    "serde",
+] }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "3.5.0", default-features = false, features = [
     "macros",


### PR DESCRIPTION
Because why not?
Used this for reference: https://github.com/torvalds/linux/blob/a9cda7c0ffedb47b23002e109bd26ab2a2ab99c9/drivers/gpu/drm/amd/pm/swsmu/smu11/cyan_skillfish_ppt.c