### PR TITLE
fix: apply pstates correctly when clocks settings are used

### DIFF
--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -873,18 +873,6 @@ impl GpuController for AmdGpuController {
                 }
             }
 
-            for (kind, states) in &config.power_states {
-                if config.performance_level != Some(PerformanceLevel::Manual) {
-                    return Err(anyhow!(
-                        "Performance level has to be set to `manual` to configure power states"
-                    ));
-                }
-
-                self.handle
-                    .set_enabled_power_levels(*kind, states)
-                    .with_context(|| format!("Could not set {kind:?} power states"))?;
-            }
-
             if config.fan_control_enabled {
                 if let Some(ref settings) = config.fan_control_settings {
                     match settings.mode {
@@ -1015,6 +1003,18 @@ impl GpuController for AmdGpuController {
 
             for handle in commit_handles {
                 handle.commit()?;
+            }
+
+            for (kind, states) in &config.power_states {
+                if config.performance_level != Some(PerformanceLevel::Manual) {
+                    return Err(anyhow!(
+                        "Performance level has to be set to `manual` to configure power states"
+                    ));
+                }
+
+                self.handle
+                    .set_enabled_power_levels(*kind, states)
+                    .with_context(|| format!("Could not set {kind:?} power states"))?;
             }
 
             Ok(())

--- a/lact-gui/src/app/pages/oc_page/mod.rs
+++ b/lact-gui/src/app/pages/oc_page/mod.rs
@@ -121,6 +121,8 @@ impl OcPage {
             .map(|info| info.vram_clock_ratio)
             .unwrap_or(1.0);
 
+        self.power_states_frame
+            .set_vram_clock_ratio(vram_clock_ratio);
         self.stats_section.set_vram_clock_ratio(vram_clock_ratio);
         self.clocks_frame.set_vram_clock_ratio(vram_clock_ratio);
     }

--- a/lact-gui/src/app/pages/oc_page/power_states/power_states_frame.rs
+++ b/lact-gui/src/app/pages/oc_page/power_states/power_states_frame.rs
@@ -26,8 +26,10 @@ impl PowerStatesFrame {
             imp.expander.set_expanded(false);
         }
 
-        imp.core_states_list.set_power_states(states.core, "MHz");
-        imp.vram_states_list.set_power_states(states.vram, "MHz");
+        imp.core_states_list
+            .set_power_states(states.core, "MHz", 1.0);
+        imp.vram_states_list
+            .set_power_states(states.vram, "MHz", self.vram_clock_ratio());
     }
 
     pub fn connect_values_changed<F: Fn() + 'static + Clone>(&self, f: F) {
@@ -76,7 +78,7 @@ mod imp {
         },
         CompositeTemplate, Expander,
     };
-    use std::sync::atomic::AtomicBool;
+    use std::{cell::Cell, sync::atomic::AtomicBool};
 
     #[derive(CompositeTemplate, Default, Properties)]
     #[properties(wrapper_type = super::PowerStatesFrame)]
@@ -91,6 +93,8 @@ mod imp {
 
         #[property(get, set)]
         configurable: AtomicBool,
+        #[property(get, set)]
+        vram_clock_ratio: Cell<f64>,
     }
 
     #[glib::object_subclass]

--- a/lact-gui/src/app/pages/oc_page/power_states/power_states_list.rs
+++ b/lact-gui/src/app/pages/oc_page/power_states/power_states_list.rs
@@ -31,9 +31,15 @@ impl PowerStatesList {
             .collect()
     }
 
-    pub fn set_power_states(&self, power_states: Vec<PowerState>, value_suffix: &str) {
+    pub fn set_power_states(
+        &self,
+        power_states: Vec<PowerState>,
+        value_suffix: &str,
+        value_ratio: f64,
+    ) {
         let store = gio::ListStore::new::<PowerStateRow>();
-        for (i, state) in power_states.into_iter().enumerate() {
+        for (i, mut state) in power_states.into_iter().enumerate() {
+            state.value = (state.value as f64 * value_ratio) as u64;
             let index = u8::try_from(i).expect("Power state index doesn't fit in u8?");
             let row = PowerStateRow::new(state, index, value_suffix);
             store.append(&row);


### PR DESCRIPTION
Fixes #421 after a regression in #340 
Tested to work on a 6900XT