### PR TITLE
perf: disable plot supersampling, add plot render benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ name = "lact"
 version = "0.7.1"
 dependencies = [
  "anyhow",
+ "divan",
  "lact-cli",
  "lact-daemon",
  "lact-gui",
@@ -1327,7 +1328,6 @@ dependencies = [
  "futures",
  "indexmap",
  "insta",
- "lact-daemon",
  "lact-schema",
  "libdrm_amdgpu_sys",
  "libflate",
@@ -1358,6 +1358,7 @@ dependencies = [
  "anyhow",
  "cairo-rs",
  "chrono",
+ "divan",
  "gtk4",
  "itertools",
  "lact-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,5 @@ opt-level = 3
 [profile.bench]
 strip = false
 debug = 1
+lto = "thin"
+codegen-units = 256

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ chrono = "0.4.31"
 indexmap = { version = "2.5.0", features = ["serde"] }
 pretty_assertions = "1.4.0"
 divan = "0.1"
+gtk = { version = "0.9", package = "gtk4" }
 
 [profile.release]
 strip = "symbols"

--- a/lact-daemon/Cargo.toml
+++ b/lact-daemon/Cargo.toml
@@ -48,14 +48,8 @@ copes = { git = "https://gitlab.com/corectrl/copes" }
 libloading = "0.8.6"
 
 [dev-dependencies]
-divan = { workspace = true }
 pretty_assertions = { workspace = true }
-lact-daemon = { path = ".", features = ["bench"] }
 insta = { version = "1.41.1", features = ["json", "yaml"] }
 
 [build-dependencies]
 bindgen = "0.68"
-
-[[bench]]
-name = "daemon"
-harness = false

--- a/lact-daemon/benches/daemon.rs
+++ b/lact-daemon/benches/daemon.rs
@@ -1,5 +1,0 @@
-fn main() {
-    // Include the daemon lib
-    let _ = lact_daemon::MODULE_CONF_PATH;
-    divan::main();
-}

--- a/lact-gui/Cargo.toml
+++ b/lact-gui/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 default = ["gtk-tests"]
 gtk-tests = []
 adw = ["dep:adw", "relm4/libadwaita"]
+bench = ["dep:divan"]
 
 [dependencies]
 lact-client = { path = "../lact-client" }
@@ -36,6 +37,8 @@ cairo-rs = { version = "0.20", default-features = false }
 itertools = "0.13.0"
 
 thread-priority = "1.1.0"
+
+divan = { workspace = true, optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/lact-gui/Cargo.toml
+++ b/lact-gui/Cargo.toml
@@ -20,8 +20,8 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
+gtk = { workspace = true, features = ["v4_6", "blueprint"] }
 
-gtk = { version = "0.9", package = "gtk4", features = ["v4_6", "blueprint"] }
 adw = { package = "libadwaita", version = "0.7.1", features = [
     "v1_4",
 ], optional = true }

--- a/lact-gui/src/app/graphs_window/mod.rs
+++ b/lact-gui/src/app/graphs_window/mod.rs
@@ -38,12 +38,13 @@ impl relm4::Component for GraphsWindow {
                 set_margin_all: 10,
                 set_row_spacing: 20,
                 set_column_spacing: 20,
+                set_column_homogeneous: true,
 
                 attach[0, 0, 1, 1]: temperature_plot = &Plot {
                     set_title: "Temperature",
                     set_hexpand: true,
                     set_value_suffix: "°C",
-                    set_y_label_area_relative_size: 0.15,
+                    set_y_label_area_relative_size: 0.2,
                     #[watch]
                     set_time_period_seconds: model.time_period_seconds_adj.value() as i64,
                 },
@@ -52,7 +53,7 @@ impl relm4::Component for GraphsWindow {
                     set_title: "Fan speed",
                     set_hexpand: true,
                     set_value_suffix: "RPM",
-                    set_y_label_area_relative_size: 0.25,
+                    set_y_label_area_relative_size: 0.3,
                     set_secondary_y_label_area_relative_size: 0.15,
                     #[watch]
                     set_time_period_seconds: model.time_period_seconds_adj.value() as i64,

--- a/lact-gui/src/app/graphs_window/plot/imp.rs
+++ b/lact-gui/src/app/graphs_window/plot/imp.rs
@@ -9,6 +9,8 @@ use std::collections::BTreeMap;
 
 use super::render_thread::{RenderRequest, RenderThread};
 
+const SUPERSAMPLE_FACTOR: u32 = 1;
+
 #[derive(Properties, Default)]
 #[properties(wrapper_type = super::Plot)]
 pub struct Plot {
@@ -75,7 +77,7 @@ impl WidgetImpl for Plot {
                 secondary_y_label_relative_area_size: self
                     .secondary_y_label_area_relative_size
                     .get(),
-                supersample_factor: 4,
+                supersample_factor: SUPERSAMPLE_FACTOR,
                 time_period_seconds: self.time_period_seconds.get(),
             });
         }
@@ -204,6 +206,8 @@ mod benches {
     use divan::{counter::ItemsCount, Bencher};
     use std::sync::Mutex;
 
+    use super::SUPERSAMPLE_FACTOR;
+
     #[divan::bench]
     fn render_plot(bencher: Bencher) {
         let last_texture = &Mutex::new(None);
@@ -221,7 +225,7 @@ mod benches {
                     data,
                     width: 1920,
                     height: 1080,
-                    supersample_factor: 4,
+                    supersample_factor: SUPERSAMPLE_FACTOR,
                     time_period_seconds: 60,
                 };
 

--- a/lact-gui/src/app/graphs_window/plot/imp.rs
+++ b/lact-gui/src/app/graphs_window/plot/imp.rs
@@ -193,3 +193,58 @@ impl PlotData {
         self.line_series.is_empty() && self.secondary_line_series.is_empty()
     }
 }
+
+#[cfg(feature = "bench")]
+mod benches {
+    use crate::app::graphs_window::plot::{
+        render_thread::{process_request, RenderRequest},
+        PlotData,
+    };
+    use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+    use divan::{counter::ItemsCount, Bencher};
+    use std::sync::Mutex;
+
+    #[divan::bench]
+    fn render_plot(bencher: Bencher) {
+        let last_texture = &Mutex::new(None);
+
+        bencher
+            .with_inputs(sample_plot_data)
+            .input_counter(|_| ItemsCount::new(1usize))
+            .bench_values(|data| {
+                let request = RenderRequest {
+                    title: "bench render".into(),
+                    value_suffix: "%".into(),
+                    secondary_value_suffix: "".into(),
+                    y_label_area_relative_size: 1.0,
+                    secondary_y_label_relative_area_size: 1.0,
+                    data,
+                    width: 1920,
+                    height: 1080,
+                    supersample_factor: 4,
+                    time_period_seconds: 60,
+                };
+
+                process_request(request, last_texture)
+            });
+    }
+
+    fn sample_plot_data() -> PlotData {
+        let mut data = PlotData::default();
+
+        // Simulate 1 minute plot with 4 values per second
+        for sec in 0..60 {
+            for milli in [0, 250, 500, 750] {
+                let datetime = NaiveDateTime::new(
+                    NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+                    NaiveTime::from_hms_milli_opt(0, 0, sec, milli).unwrap(),
+                );
+
+                data.push_line_series_with_time("GPU", 100.0, datetime);
+                data.push_secondary_line_series_with_time("GPU Secondary", 10.0, datetime);
+            }
+        }
+
+        data
+    }
+}

--- a/lact-gui/src/app/graphs_window/plot/imp.rs
+++ b/lact-gui/src/app/graphs_window/plot/imp.rs
@@ -105,14 +105,19 @@ impl PlotData {
         self.push_secondary_line_series_with_time(name, point, chrono::Local::now().naive_local());
     }
 
-    fn push_line_series_with_time(&mut self, name: &str, point: f64, time: NaiveDateTime) {
+    pub(super) fn push_line_series_with_time(
+        &mut self,
+        name: &str,
+        point: f64,
+        time: NaiveDateTime,
+    ) {
         self.line_series
             .entry(name.to_owned())
             .or_default()
             .push((time.and_utc().timestamp_millis(), point));
     }
 
-    pub fn push_secondary_line_series_with_time(
+    pub(super) fn push_secondary_line_series_with_time(
         &mut self,
         name: &str,
         point: f64,

--- a/lact-gui/src/app/graphs_window/plot/render_thread.rs
+++ b/lact-gui/src/app/graphs_window/plot/render_thread.rs
@@ -343,12 +343,12 @@ impl RenderRequest {
                                 (current_date, segment.evaluate(current_date))
                             })
                         }),
-                    Palette99::pick(idx).stroke_width(8),
+                    Palette99::pick(idx).stroke_width(2),
                 ))
                 .context("Failed to draw series")?
                 .label(caption)
                 .legend(move |(x, y)| {
-                    let offset = self.relative_size(0.04) as i32;
+                    let offset = self.relative_size(0.02) as i32;
                     Rectangle::new(
                         [(x - offset, y - offset), (x + offset, y + offset)],
                         Palette99::pick(idx).filled(),
@@ -367,12 +367,12 @@ impl RenderRequest {
                                 (current_date, segment.evaluate(current_date))
                             })
                         }),
-                    Palette99::pick(idx + 10).stroke_width(8),
+                    Palette99::pick(idx + 10).stroke_width(2),
                 ))
                 .context("Failed to draw series")?
                 .label(caption)
                 .legend(move |(x, y)| {
-                    let offset = self.relative_size(0.04) as i32;
+                    let offset = self.relative_size(0.02) as i32;
                     Rectangle::new(
                         [(x - offset, y - offset), (x + offset, y + offset)],
                         Palette99::pick(idx + 10).filled(),

--- a/lact/Cargo.toml
+++ b/lact/Cargo.toml
@@ -13,3 +13,12 @@ lact-schema = { path = "../lact-schema", features = ["args"] }
 lact-cli = { path = "../lact-cli" }
 lact-gui = { path = "../lact-gui", optional = true }
 anyhow = { workspace = true }
+
+[dev-dependencies]
+divan = { workspace = true }
+lact-daemon = { path = "../lact-daemon", features = ["bench"] }
+lact-gui = { path = "../lact-gui", features = ["bench"] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/lact/benches/bench.rs
+++ b/lact/benches/bench.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Include crates in the binary
+    let _ = lact_daemon::run;
+    let _ = lact_gui::run;
+
+    divan::main();
+}


### PR DESCRIPTION
There are 2 major issues with supersampling when rendering the plot:
- Rendering the plot texture itself is slow, taking ~30ms to render a 1080p plot with 4x supersampling. Even though this is done in a background thread, it's still a significant amount of system resources used just to render the plots
- With the GTK vulkan backend, which is the default on recent versions, drawing and downscaling the texture is exceedingly slow. At least with nvidia drivers (i was not able to confirm this happening on other drivers), maximizing the graphs window makes the entire system lag, with a profiler pointing to most of the time being spent on vulkan texture allocation calls. Which makes sense, as it's allocating textures of extremely high resolutions due to 4x supersampling. GTK's old GL backend handles this better, with no whole-system lag, but the rendering is still slow and cpu usage is significant.

Due to this unacceptable slowdown the supersampling is removed. It makes the graphs look worse, but they are still legible.

