### PR TITLE
doc: Update link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All of the functionality works regardless of the desktop session (there is no de
 - Otherwise, build from source.
 
 **Why is there no AppImage/Flatpak/other universal format?**
-See [here](./pkg/README.md).
+See [here](./pkg/README.md#why-is-there-no-appimageflatpakdocker).
 
 Note: Nvidia support requires the Nvidia proprietary driver with CUDA libraries installed.
 


### PR DESCRIPTION
Add fragment so that link jumps to section explaining why there is no universal package format