### PR TITLE
fix: reliably cleanup old fan control tasks on gpu reload events, limit number of fan control retry attempts

### DIFF
--- a/lact-daemon/src/server/gpu_controller.rs
+++ b/lact-daemon/src/server/gpu_controller.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use amdgpu_sysfs::gpu_handle::power_profile_mode::PowerProfileModesTable;
 use anyhow::Context;
-use futures::future::LocalBoxFuture;
+use futures::{future::LocalBoxFuture, FutureExt};
 use lact_schema::{ClocksInfo, DeviceInfo, DeviceStats, GpuPciInfo, PciInfo, PowerStates};
 use libdrm_amdgpu_sys::LibDrmAmdgpu;
 use nvml_wrapper::Nvml;
@@ -46,7 +46,11 @@ pub trait GpuController {
 
     fn reset_pmfw_settings(&self);
 
-    fn cleanup_clocks(&self) -> anyhow::Result<()>;
+    fn cleanup(&self) -> LocalBoxFuture<'_, ()> {
+        async {}.boxed_local()
+    }
+
+    fn reset_clocks(&self) -> anyhow::Result<()>;
 
     fn get_power_profile_modes(&self) -> anyhow::Result<PowerProfileModesTable>;
 

--- a/lact-daemon/src/server/gpu_controller/intel.rs
+++ b/lact-daemon/src/server/gpu_controller/intel.rs
@@ -702,7 +702,7 @@ impl GpuController for IntelGpuController {
     fn reset_pmfw_settings(&self) {}
 
     #[allow(clippy::cast_possible_truncation)]
-    fn cleanup_clocks(&self) -> anyhow::Result<()> {
+    fn reset_clocks(&self) -> anyhow::Result<()> {
         if let Some(rp0) = self.read_freq(FrequencyType::Rp0) {
             if let Err(err) = self.write_freq(FrequencyType::Max, rp0 as i32) {
                 warn!("could not reset max clock: {err:#}");

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -117,6 +117,7 @@ impl<'a> Handler {
             controllers = load_controllers(base_path, pci_db)?;
 
             let mut should_retry = false;
+            #[cfg(not(test))]
             if let Ok(devices) = fs::read_dir("/sys/bus/pci/devices") {
                 for device in devices.flatten() {
                     if let Ok(uevent) = fs::read_to_string(device.path().join("uevent")) {

--- a/lact-daemon/src/server/system.rs
+++ b/lact-daemon/src/server/system.rs
@@ -13,7 +13,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 use tokio::{process::Command, sync::Notify};
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 static OC_TOGGLED: AtomicBool = AtomicBool::new(false);
 
@@ -230,7 +230,6 @@ pub(crate) fn listen_netlink_kernel_event(notify: &Notify) -> anyhow::Result<()>
                         continue;
                     }
 
-                    debug!("kernel event line: '{line}'");
                     if let Some(subsystem) = line.strip_prefix("SUBSYSTEM=") {
                         if subsystem == "drm" {
                             notify.notify_one();

--- a/lact-daemon/src/suspend.rs
+++ b/lact-daemon/src/suspend.rs
@@ -10,9 +10,7 @@ pub async fn listen_events(handler: Handler) {
             Ok(mut stream) => {
                 while stream.next().await.is_some() {
                     info!("suspend/resume event detected, reloading config");
-                    if let Err(err) = handler.apply_current_config().await {
-                        error!("could not reapply config: {err:#}");
-                    }
+                    handler.reload_gpus().await;
                 }
             }
             Err(err) => error!("could not subscribe to suspend events: {err:#}"),


### PR DESCRIPTION
Fixes #493 and improves the reliability of fan control tasks after GPU reload events (such as suspend/resume).