### PR TITLE
feat: update socket permissions configuration, add admin_user field

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See the [Wiki page](https://github.com/ilya-zlobintsev/LACT/wiki/Hardware-Suppor
 
 # Configuration
 
-There is a configuration file available in `/etc/lact/config.yaml`. Most of the settings are accessible through the GUI, but some of them may be useful to be edited manually (like `admin_groups` to specify who has access to the daemon)
+There is a configuration file available in `/etc/lact/config.yaml`. Most of the settings are accessible through the GUI, but some of them may be useful to be edited manually (like `admin_group` and `admin_user` to specify who has access to the daemon)
 
 See [CONFIG.md](./docs/CONFIG.md) for more information.
 
@@ -76,11 +76,14 @@ See [CONFIG.md](./docs/CONFIG.md) for more information.
 
 By default, LACT uses either ether the `wheel` or `sudo` group (whichever is available) for the ownership of the unix socket that the GUI needs to connect to.
 
-On most configurations (such as the default setup on Arch-based, most Debian-based or Fedora systems) you do not need to do anything.
+On most desktop configurations (such as the default setup on Arch-based, most Debian-based or Fedora systems) this includes the default user, so you do not need to configure this.
 
 However, some systems may have different user configuration. In particular, this has been reported to be a problem on OpenSUSE.
 
-To fix socket permissions in such configurations, edit `/etc/lact/config.yaml` and add your username or group as the first entry in `admin_groups` under `daemon`, and restart the service (`sudo systemctl restart lactd`).
+To fix socket permissions in such configurations, edit `/etc/lact/config.yaml` and under the `daemon` section either:
+- Set `admin_user` to your username
+- Set `admin_group` to a group that your user is a part of 
+Then restart the service (`sudo systemctl restart lactd`).
 
 # Overclocking (AMD)
 
@@ -153,9 +156,7 @@ Example:
 daemon:
   tcp_listen_address: 0.0.0.0:12853
   log_level: info
-  admin_groups:
-  - wheel
-  - sudo
+  admin_group: wheel
   disable_clocks_cleanup: false
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Description
 
-The LACT Daemon exposes a JSON API over a unix socket or TCP, available on `/var/run/lactd.sock` or an arbitrary TCP port. You can configure who has access to the unix socket in `/etc/lact/config.yaml` in the `daemon.admin_groups` field. The TCP listener is disabled by default for security reasons, see [this README section](../README.md#remote-management) for how to enable it.
+The LACT Daemon exposes a JSON API over a unix socket or TCP, available on `/var/run/lactd.sock` or an arbitrary TCP port. You can configure who has access to the unix socket in `/etc/lact/config.yaml` in the `daemon.admin_group` or `daemon.admin_user` field. The TCP listener is disabled by default for security reasons, see [this README section](../README.md#remote-management) for how to enable it.
 
 The API expects newline-separated JSON objects, and returns a JSON object for every request.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -11,13 +11,14 @@ daemon:
   # The logging level of the daemon.
   # Possible values: `error`, `warn`, `info` (default), `debug`, `trace`
   log_level: info
-  # User groups who should have access to the daemon.
-  # WARNING: only the first group from this list that is found on the system is used!
-  # This is made a list and not a single value to allow this config to work across 
-  # different distros, which might have different groups for an "admin" user.
-  admin_groups:
-  - wheel
-  - sudo
+  # User group that owns the daemon socket.
+  # Any user in this group will be able to use the daemon.
+  # Access can also be granted with the `admin_user` setting. 
+  admin_group: wheel
+  # User that owns the daemon socket.
+  # This user will have access to the daemon, even if they are not in the part of the `admin_group` group.    
+  # Not set by default.
+  admin_user: foo
   # If set to `true`, this setting makes the LACT daemon not reset
   # GPU clocks when changing other settings or when turning off the daemon.
   # Can be used to work around a few very specific issues with 

--- a/lact-daemon/src/server.rs
+++ b/lact-daemon/src/server.rs
@@ -25,7 +25,10 @@ pub struct Server {
 
 impl Server {
     pub async fn new(config: Config) -> anyhow::Result<Self> {
-        let unix_listener = socket::listen(&config.daemon.admin_groups)?;
+        let unix_listener = socket::listen(
+            config.daemon.admin_group.as_deref(),
+            config.daemon.admin_user.as_deref(),
+        )?;
 
         let tcp_listener = if let Some(address) = &config.daemon.tcp_listen_address {
             let listener = TcpListener::bind(address)

--- a/lact-daemon/src/snapshots/lact_daemon__config__tests__parse_doc.snap
+++ b/lact-daemon/src/snapshots/lact_daemon__config__tests__parse_doc.snap
@@ -5,9 +5,8 @@ expression: deserialized_config
 version: 0
 daemon:
   log_level: info
-  admin_groups:
-    - wheel
-    - sudo
+  admin_user: foo
+  admin_group: wheel
   disable_clocks_cleanup: false
   tcp_listen_address: "127.0.0.1:12853"
 apply_settings_timer: 5


### PR DESCRIPTION
These changes should make permissions configuration clearer:
- The `admin_groups` field is replaced with a `admin_group`. Previously only the first group that existed on the system in this array was used, which is not very clear behaviour. Existing group configuration will be automatically migrated to the new field.
- A new `admin_user` field is added. It directly sets the owner of the lact socket. This setting coexists with the group setting, and any user who is either `admin_user` or in the `admin_group` group will be able to access it. The field is not set by default.