### PR TITLE
chore: add PowerColor RX 7900 XTX Red Devil to database

### DIFF
--- a/res/device_ids.json
+++ b/res/device_ids.json
@@ -63,6 +63,9 @@
       "1043": {
         "05ed": "ASUS TUF Gaming RX 7900 XT OC",
         "0506": "ASUS TUF Gaming RX 7900 XTX OC"
+      },
+      "148c": {
+        "2422": "PowerColor RX 7900 XTX Red Devil"
       }
     },
     "73bf": {


### PR DESCRIPTION
```
$ lact cli info
GPU 1002:744C-148C:2422-0000:03:00.0:
=====================================
GPU Model: AMD Radeon RX 7900 XTX (0x1002:0x744C:0xC8)
Card Manufacturer: Tul Corporation / PowerColor (0x148C)
Card Model: PowerColor RX 7900 XTX Red Devil (0x2422)
Driver Used: amdgpu
VBIOS Version: 022.001.002.009.000001 [2022/11/21 22:47]
VRAM Size: 24560 MiB
GPU Family: GC 11.0.0
ASIC Name: GFX1100/Navi31
Compute Units: 96
VRAM Type: GDDR6
VRAM Manufacturer: samsung
Theoretical VRAM Bandwidth: 959
L1 Cache (Per CU): 32 KiB
L2 Cache: 6144 KiB
L3 Cache: 96 MiB
Resizeable bar: Enabled
CPU Accessible VRAM: 24560
Link Speed: 16.0 GT/s PCIe x16
```