### PR TITLE
Update device_ids.json

### DIFF
--- a/res/device_ids.json
+++ b/res/device_ids.json
@@ -26,7 +26,7 @@
         "0618": "ASUS PRIME RX 9070"
       },
       "1eae": {
-        "8810": "XFX Swift White RX 9070 XT",
+        "8810": "XFX Swift RX 9070 XT",
         "8811": "XFX Mercury/Swift RX 9070 XT",
         "8710": "XFX Swift RX 9070"
       },


### PR DESCRIPTION
XFX Swift RX 9070 XT black and white likely share same id. (Black version reporting same ID) Remove "White" to reflect the general model.