### PR TITLE
chore(lact-daemon): make nvidia bindgen feature as optional

### DIFF
--- a/lact-daemon/Cargo.toml
+++ b/lact-daemon/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.7.3"
 edition = "2021"
 
 [features]
-default = []
+default = ["nvidia"]
 bench = ["dep:divan"]
+nvidia = []
 
 [dependencies]
 lact-schema = { path = "../lact-schema" }

--- a/lact-daemon/build.rs
+++ b/lact-daemon/build.rs
@@ -8,7 +8,10 @@ fn main() {
     println!("cargo::rerun-if-changed=include/");
 
     gen_intel_bindings();
+
+    #[cfg(feature = "nvidia")]
     gen_nvidia_bindings();
+
     gen_vulkan_constants();
 }
 
@@ -26,6 +29,7 @@ fn gen_intel_bindings() {
         .expect("Couldn't write bindings!");
 }
 
+#[cfg(feature = "nvidia")]
 fn gen_nvidia_bindings() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 

--- a/lact-daemon/src/bindings.rs
+++ b/lact-daemon/src/bindings.rs
@@ -12,6 +12,7 @@ pub mod intel {
     include!(concat!(env!("OUT_DIR"), "/intel_bindings.rs"));
 }
 
+#[cfg(feature = "nvidia")]
 pub mod nvidia {
     include!(concat!(env!("OUT_DIR"), "/nvidia_bindings.rs"));
 }

--- a/lact/Cargo.toml
+++ b/lact/Cargo.toml
@@ -4,12 +4,13 @@ version = "0.7.3"
 edition = "2021"
 
 [features]
-default = ["lact-gui"]
+default = ["lact-gui", "nvidia"]
 adw = ["lact-gui/adw"]
 flatpak = ["dep:configparser"]
+nvidia = ["lact-daemon/nvidia"]
 
 [dependencies]
-lact-daemon = { path = "../lact-daemon" }
+lact-daemon = { path = "../lact-daemon", default-features = false }
 lact-schema = { path = "../lact-schema", features = ["args"] }
 lact-cli = { path = "../lact-cli" }
 lact-gui = { path = "../lact-gui", optional = true }


### PR DESCRIPTION
to fix loongson3 and loongarch64 architecture build