### PR TITLE
feat: new GPU config socket API

### DIFF
--- a/lact-daemon/src/server.rs
+++ b/lact-daemon/src/server.rs
@@ -186,6 +186,7 @@ async fn handle_request<'a>(request: Request<'a>, handler: &'a Handler) -> anyho
         Request::SetProfileRule { name, rule } => {
             ok_response(handler.set_profile_rule(&name, rule).await?)
         }
+        Request::GetGpuConfig { id } => ok_response(handler.get_gpu_config(id).await?),
         Request::EnableOverdrive => ok_response(system::enable_overdrive().await?),
         Request::DisableOverdrive => ok_response(system::disable_overdrive().await?),
         Request::GenerateSnapshot => ok_response(handler.generate_snapshot().await?),

--- a/lact-daemon/src/server.rs
+++ b/lact-daemon/src/server.rs
@@ -187,6 +187,9 @@ async fn handle_request<'a>(request: Request<'a>, handler: &'a Handler) -> anyho
             ok_response(handler.set_profile_rule(&name, rule).await?)
         }
         Request::GetGpuConfig { id } => ok_response(handler.get_gpu_config(id).await?),
+        Request::SetGpuConfig { id, config } => {
+            ok_response(handler.set_gpu_config(id, config).await?)
+        }
         Request::EnableOverdrive => ok_response(system::enable_overdrive().await?),
         Request::DisableOverdrive => ok_response(system::disable_overdrive().await?),
         Request::GenerateSnapshot => ok_response(handler.generate_snapshot().await?),

--- a/lact-daemon/src/server/gpu_controller.rs
+++ b/lact-daemon/src/server/gpu_controller.rs
@@ -15,14 +15,13 @@ use nvidia::NvidiaGpuController;
 pub const VENDOR_AMD: &str = "1002";
 pub const VENDOR_NVIDIA: &str = "10DE";
 
-use crate::{
-    bindings::intel::IntelDrm,
-    config::{self},
-};
+use crate::bindings::intel::IntelDrm;
 use amdgpu_sysfs::gpu_handle::power_profile_mode::PowerProfileModesTable;
 use anyhow::Context;
 use futures::{future::LocalBoxFuture, FutureExt};
-use lact_schema::{ClocksInfo, DeviceInfo, DeviceStats, GpuPciInfo, PciInfo, PowerStates};
+use lact_schema::{
+    config::GpuConfig, ClocksInfo, DeviceInfo, DeviceStats, GpuPciInfo, PciInfo, PowerStates,
+};
 use libdrm_amdgpu_sys::LibDrmAmdgpu;
 use nvml_wrapper::Nvml;
 use std::{cell::LazyCell, collections::HashMap, fs, path::PathBuf, rc::Rc};
@@ -37,16 +36,13 @@ pub trait GpuController {
 
     fn get_info(&self) -> LocalBoxFuture<'_, DeviceInfo>;
 
-    fn apply_config<'a>(
-        &'a self,
-        config: &'a config::Gpu,
-    ) -> LocalBoxFuture<'a, anyhow::Result<()>>;
+    fn apply_config<'a>(&'a self, config: &'a GpuConfig) -> LocalBoxFuture<'a, anyhow::Result<()>>;
 
-    fn get_stats(&self, gpu_config: Option<&config::Gpu>) -> DeviceStats;
+    fn get_stats(&self, gpu_config: Option<&GpuConfig>) -> DeviceStats;
 
-    fn get_clocks_info(&self, gpu_config: Option<&config::Gpu>) -> anyhow::Result<ClocksInfo>;
+    fn get_clocks_info(&self, gpu_config: Option<&GpuConfig>) -> anyhow::Result<ClocksInfo>;
 
-    fn get_power_states(&self, gpu_config: Option<&config::Gpu>) -> PowerStates;
+    fn get_power_states(&self, gpu_config: Option<&GpuConfig>) -> PowerStates;
 
     fn reset_pmfw_settings(&self);
 

--- a/lact-daemon/src/server/gpu_controller/intel.rs
+++ b/lact-daemon/src/server/gpu_controller/intel.rs
@@ -6,16 +6,15 @@ use crate::{
         drm_i915_gem_memory_class_I915_MEMORY_CLASS_DEVICE,
         drm_xe_memory_class_DRM_XE_MEM_REGION_CLASS_VRAM, IntelDrm,
     },
-    config,
     server::vulkan::get_vulkan_info,
 };
 use amdgpu_sysfs::{gpu_handle::power_profile_mode::PowerProfileModesTable, hw_mon::Temperature};
 use anyhow::{anyhow, Context};
 use futures::future::LocalBoxFuture;
 use lact_schema::{
-    ClocksInfo, ClocksTable, ClockspeedStats, DeviceInfo, DeviceStats, DrmInfo, DrmMemoryInfo,
-    FanStats, IntelClocksTable, IntelDrmInfo, LinkInfo, PowerState, PowerStates, PowerStats,
-    VoltageStats, VramStats,
+    config::GpuConfig, ClocksInfo, ClocksTable, ClockspeedStats, DeviceInfo, DeviceStats, DrmInfo,
+    DrmMemoryInfo, FanStats, IntelClocksTable, IntelDrmInfo, LinkInfo, PowerState, PowerStates,
+    PowerStats, VoltageStats, VramStats,
 };
 use std::{
     cell::Cell,
@@ -594,10 +593,7 @@ impl GpuController for IntelGpuController {
     }
 
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    fn apply_config<'a>(
-        &'a self,
-        config: &'a config::Gpu,
-    ) -> LocalBoxFuture<'a, anyhow::Result<()>> {
+    fn apply_config<'a>(&'a self, config: &'a GpuConfig) -> LocalBoxFuture<'a, anyhow::Result<()>> {
         Box::pin(async {
             if let Some(max_clock) = config.clocks_configuration.max_core_clock {
                 self.write_freq(FrequencyType::Max, max_clock)
@@ -618,7 +614,7 @@ impl GpuController for IntelGpuController {
         })
     }
 
-    fn get_stats(&self, _gpu_config: Option<&config::Gpu>) -> DeviceStats {
+    fn get_stats(&self, _gpu_config: Option<&GpuConfig>) -> DeviceStats {
         let current_gfxclk = self.read_freq(FrequencyType::Cur);
         let gpu_clockspeed = self
             .read_freq(FrequencyType::Act)
@@ -684,7 +680,7 @@ impl GpuController for IntelGpuController {
         }
     }
 
-    fn get_clocks_info(&self, _gpu_config: Option<&config::Gpu>) -> anyhow::Result<ClocksInfo> {
+    fn get_clocks_info(&self, _gpu_config: Option<&GpuConfig>) -> anyhow::Result<ClocksInfo> {
         let clocks_table = IntelClocksTable {
             gt_freq: self
                 .read_freq(FrequencyType::Min)
@@ -706,7 +702,7 @@ impl GpuController for IntelGpuController {
         })
     }
 
-    fn get_power_states(&self, _gpu_config: Option<&config::Gpu>) -> PowerStates {
+    fn get_power_states(&self, _gpu_config: Option<&GpuConfig>) -> PowerStates {
         let core = [
             FrequencyType::Rpn,
             FrequencyType::Rpe,

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -939,6 +939,11 @@ impl<'a> Handler {
         Ok(config.gpus()?.get(id).cloned())
     }
 
+    pub async fn set_gpu_config(&self, id: &str, new_config: GpuConfig) -> anyhow::Result<u64> {
+        self.edit_gpu_config(id.to_owned(), |config| *config = new_config)
+            .await
+    }
+
     pub fn evaluate_profile_rule(&self, rule: &ProfileRule) -> anyhow::Result<bool> {
         let profile_watcher_state_guard = self.profile_watcher_state.borrow();
         match profile_watcher_state_guard.as_ref() {

--- a/lact-daemon/src/tests/mod.rs
+++ b/lact-daemon/src/tests/mod.rs
@@ -1,10 +1,8 @@
 mod mock_fs;
 
-use crate::{
-    config::{self, Config},
-    server::handler::Handler,
-};
+use crate::{config::Config, server::handler::Handler};
 use insta::{assert_debug_snapshot, assert_json_snapshot};
+use lact_schema::config::GpuConfig;
 use mock_fs::MockSysfs;
 use std::{fs, path::PathBuf, sync::OnceLock};
 use tempfile::tempdir;
@@ -66,7 +64,7 @@ async fn apply_settings() {
                         vendor_dir.file_name().to_string_lossy(),
                         device_dir.file_name().to_string_lossy()
                     );
-                    let gpu_config: config::Gpu = serde_yaml::from_str(&raw_gpu_config).unwrap();
+                    let gpu_config: GpuConfig = serde_yaml::from_str(&raw_gpu_config).unwrap();
 
                     let mock_fs_dir = tempdir().unwrap();
 

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -8,7 +8,6 @@ mod page_section;
 mod pages;
 
 use crate::{APP_ID, GUI_VERSION};
-use amdgpu_sysfs::gpu_handle::PerformanceLevel;
 use anyhow::{anyhow, Context};
 use apply_revealer::{ApplyRevealer, ApplyRevealerMsg};
 use confirmation_dialog::ConfirmationDialog;
@@ -592,19 +591,17 @@ impl AppModel {
         if let Some(level) = performance_level {
             gpu_config.performance_level = Some(level);
 
-            if level == PerformanceLevel::Auto {
-                gpu_config.power_profile_mode_index = self
-                    .oc_page
-                    .model()
-                    .performance_frame
-                    .get_selected_power_profile_mode();
+            gpu_config.power_profile_mode_index = self
+                .oc_page
+                .model()
+                .performance_frame
+                .get_selected_power_profile_mode();
 
-                gpu_config.custom_power_profile_mode_hueristics = self
-                    .oc_page
-                    .model()
-                    .performance_frame
-                    .get_power_profile_mode_custom_heuristics();
-            }
+            gpu_config.custom_power_profile_mode_hueristics = self
+                .oc_page
+                .model()
+                .performance_frame
+                .get_power_profile_mode_custom_heuristics();
         }
 
         if let Some(thermals_settings) = self.thermals_page.get_thermals_settings() {

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -8,6 +8,7 @@ mod page_section;
 mod pages;
 
 use crate::{APP_ID, GUI_VERSION};
+use amdgpu_sysfs::gpu_handle::PerformanceLevel;
 use anyhow::{anyhow, Context};
 use apply_revealer::{ApplyRevealer, ApplyRevealerMsg};
 use confirmation_dialog::ConfirmationDialog;
@@ -27,8 +28,9 @@ use header::{
 use lact_client::{ConnectionStatusMsg, DaemonClient};
 use lact_schema::{
     args::GuiArgs,
+    config::{FanControlSettings, FanCurve, GpuConfig},
     request::{ConfirmCommand, SetClocksCommand},
-    DeviceStats, FanOptions, GIT_COMMIT,
+    DeviceStats, GIT_COMMIT,
 };
 use msg::AppMsg;
 use pages::{
@@ -572,114 +574,88 @@ impl AppModel {
         root: &gtk::ApplicationWindow,
         sender: &AsyncComponentSender<Self>,
     ) -> anyhow::Result<()> {
-        // TODO: Ask confirmation for everything, not just clocks
-
         debug!("applying settings on gpu {gpu_id}");
+
+        let mut gpu_config = self
+            .daemon_client
+            .get_gpu_config(&gpu_id)
+            .await
+            .context("Could not get gpu config")?
+            .unwrap_or_else(GpuConfig::default);
 
         let cap = self.oc_page.model().get_power_cap();
         if let Some(cap) = cap {
-            self.daemon_client
-                .set_power_cap(&gpu_id, Some(cap))
-                .await
-                .context("Failed to set power cap")?;
-
-            self.daemon_client
-                .confirm_pending_config(ConfirmCommand::Confirm)
-                .await
-                .context("Could not commit config")?;
+            gpu_config.power_cap = Some(cap);
         }
-
-        // Reset the power profile mode for switching to/from manual performance level
-        self.daemon_client
-            .set_power_profile_mode(&gpu_id, None, vec![])
-            .await
-            .context("Could not set default power profile mode")?;
-        self.daemon_client
-            .confirm_pending_config(ConfirmCommand::Confirm)
-            .await
-            .context("Could not commit config")?;
 
         let performance_level = self.oc_page.model().get_performance_level();
         if let Some(level) = performance_level {
-            self.daemon_client
-                .set_performance_level(&gpu_id, level)
-                .await
-                .context("Failed to set power profile")?;
-            self.daemon_client
-                .confirm_pending_config(ConfirmCommand::Confirm)
-                .await
-                .context("Could not commit config")?;
+            gpu_config.performance_level = Some(level);
 
-            let mode_index = self
-                .oc_page
-                .model()
-                .performance_frame
-                .get_selected_power_profile_mode();
-            let custom_heuristics = self
-                .oc_page
-                .model()
-                .performance_frame
-                .get_power_profile_mode_custom_heuristics();
+            if level == PerformanceLevel::Auto {
+                gpu_config.power_profile_mode_index = self
+                    .oc_page
+                    .model()
+                    .performance_frame
+                    .get_selected_power_profile_mode();
 
-            self.daemon_client
-                .set_power_profile_mode(&gpu_id, mode_index, custom_heuristics)
-                .await
-                .context("Could not set active power profile mode")?;
-            self.daemon_client
-                .confirm_pending_config(ConfirmCommand::Confirm)
-                .await
-                .context("Could not commit config")?;
+                gpu_config.custom_power_profile_mode_hueristics = self
+                    .oc_page
+                    .model()
+                    .performance_frame
+                    .get_power_profile_mode_custom_heuristics();
+            }
         }
 
         if let Some(thermals_settings) = self.thermals_page.get_thermals_settings() {
             debug!("applying thermal settings: {thermals_settings:?}");
-            let opts = FanOptions {
-                id: &gpu_id,
-                enabled: thermals_settings.manual_fan_control,
-                mode: thermals_settings.mode,
-                static_speed: thermals_settings.static_speed,
-                curve: thermals_settings.curve,
-                pmfw: thermals_settings.pmfw,
-                spindown_delay_ms: thermals_settings.spindown_delay_ms,
-                change_threshold: thermals_settings.change_threshold,
-            };
+            let mut fan_config = gpu_config
+                .fan_control_settings
+                .take()
+                .unwrap_or_else(FanControlSettings::default);
 
-            self.daemon_client
-                .set_fan_control(opts)
-                .await
-                .context("Could not set fan control")?;
-            self.daemon_client
-                .confirm_pending_config(ConfirmCommand::Confirm)
-                .await
-                .context("Could not commit config")?;
+            gpu_config.fan_control_enabled = thermals_settings.manual_fan_control;
+            gpu_config.pmfw_options = thermals_settings.pmfw;
+
+            if let Some(mode) = thermals_settings.mode {
+                fan_config.mode = mode;
+            }
+            if let Some(static_speed) = thermals_settings.static_speed {
+                fan_config.static_speed = static_speed;
+            }
+            if let Some(curve) = thermals_settings.curve {
+                fan_config.curve = FanCurve(curve);
+            }
+            fan_config.spindown_delay_ms = thermals_settings.spindown_delay_ms;
+            fan_config.change_threshold = thermals_settings.change_threshold;
+
+            gpu_config.fan_control_settings = Some(fan_config);
         }
 
         let clocks_commands = self.oc_page.model().get_clocks_commands();
 
         debug!("applying clocks commands {clocks_commands:#?}");
 
+        for command in clocks_commands {
+            gpu_config.apply_clocks_command(&command);
+        }
+
         let enabled_power_states = self.oc_page.model().get_enabled_power_states();
 
-        for (kind, states) in enabled_power_states {
-            self.daemon_client
-                .set_enabled_power_states(&gpu_id, kind, states)
-                .await
-                .context("Could not set power states")?;
-
-            self.daemon_client
-                .confirm_pending_config(ConfirmCommand::Confirm)
-                .await
-                .context("Could not commit config")?;
+        for (kind, enabled_states) in enabled_power_states {
+            if enabled_states.is_empty() {
+                gpu_config.power_states.shift_remove(&kind);
+            } else {
+                gpu_config.power_states.insert(kind, enabled_states);
+            }
         }
 
-        if !clocks_commands.is_empty() {
-            let delay = self
-                .daemon_client
-                .batch_set_clocks_value(&gpu_id, clocks_commands)
-                .await
-                .context("Could not commit clocks settings")?;
-            self.ask_settings_confirmation(delay, root, sender).await;
-        }
+        let delay = self
+            .daemon_client
+            .set_gpu_config(&gpu_id, gpu_config)
+            .await
+            .context("Could not apply settings")?;
+        self.ask_settings_confirmation(delay, root, sender).await;
 
         sender.input(AppMsg::ReloadData { full: false });
 

--- a/lact-schema/Cargo.toml
+++ b/lact-schema/Cargo.toml
@@ -10,6 +10,7 @@ args = ["clap"]
 amdgpu-sysfs = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
+serde_json = { workspace = true }
 anyhow = { workspace = true }
 indexmap = { workspace = true }
 
@@ -18,6 +19,3 @@ clap = { version = "4.4.18", features = ["derive"], optional = true }
 
 [build-dependencies]
 vergen = { version = "8.0.0", features = ["git", "gitcl"] }
-
-[dev-dependencies]
-serde_json = { workspace = true }

--- a/lact-schema/src/config.rs
+++ b/lact-schema/src/config.rs
@@ -125,3 +125,22 @@ impl Default for FanControlSettings {
 pub fn default_fan_static_speed() -> f32 {
     0.5
 }
+
+#[cfg(test)]
+mod tests {
+    use super::GpuConfig;
+
+    #[test]
+    fn deserialize_config_json() {
+        let data = r#"{"fan_control_enabled":false,"fan_control_settings":{"mode":"curve","static_speed":0.5938412,"temperature_key":"edge","interval_ms":500,"curve":{"40":0.3,"50":0.35,"60":0.5,"70":0.75,"80":1.0},"spindown_delay_ms":1000,"change_threshold":2},"power_cap":318.0,"gpu_clock_offsets":{"0":-64}}"#;
+        let config: GpuConfig = serde_json::from_str(data).unwrap();
+        assert_eq!(
+            -64,
+            *config
+                .clocks_configuration
+                .gpu_clock_offsets
+                .get(&0)
+                .unwrap()
+        );
+    }
+}

--- a/lact-schema/src/config.rs
+++ b/lact-schema/src/config.rs
@@ -1,0 +1,127 @@
+use amdgpu_sysfs::gpu_handle::{PerformanceLevel, PowerLevelKind};
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use crate::{
+    default_fan_curve,
+    request::{ClockspeedType, SetClocksCommand},
+    FanControlMode, FanCurveMap, PmfwOptions,
+};
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct GpuConfig {
+    #[serde(default)]
+    pub fan_control_enabled: bool,
+    pub fan_control_settings: Option<FanControlSettings>,
+    #[serde(default, skip_serializing_if = "PmfwOptions::is_empty")]
+    pub pmfw_options: PmfwOptions,
+    pub power_cap: Option<f64>,
+    pub performance_level: Option<PerformanceLevel>,
+    #[serde(default, flatten)]
+    pub clocks_configuration: ClocksConfiguration,
+    pub power_profile_mode_index: Option<u16>,
+    /// Outer vector is for power profile components, inner vector is for the heuristics within a component
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_power_profile_mode_hueristics: Vec<Vec<Option<i32>>>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub power_states: IndexMap<PowerLevelKind, Vec<u8>>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ClocksConfiguration {
+    pub min_core_clock: Option<i32>,
+    pub min_memory_clock: Option<i32>,
+    pub min_voltage: Option<i32>,
+    pub max_core_clock: Option<i32>,
+    pub max_memory_clock: Option<i32>,
+    pub max_voltage: Option<i32>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub gpu_clock_offsets: IndexMap<u32, i32>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub mem_clock_offsets: IndexMap<u32, i32>,
+    pub voltage_offset: Option<i32>,
+}
+
+impl GpuConfig {
+    pub fn is_core_clocks_used(&self) -> bool {
+        self.clocks_configuration != ClocksConfiguration::default()
+    }
+
+    pub fn apply_clocks_command(&mut self, command: &SetClocksCommand) {
+        let clocks = &mut self.clocks_configuration;
+        let value = command.value;
+        match command.r#type {
+            ClockspeedType::MaxCoreClock => clocks.max_core_clock = value,
+            ClockspeedType::MaxMemoryClock => clocks.max_memory_clock = value,
+            ClockspeedType::MaxVoltage => clocks.max_voltage = value,
+            ClockspeedType::MinCoreClock => clocks.min_core_clock = value,
+            ClockspeedType::MinMemoryClock => clocks.min_memory_clock = value,
+            ClockspeedType::MinVoltage => clocks.min_voltage = value,
+            ClockspeedType::VoltageOffset => clocks.voltage_offset = value,
+            ClockspeedType::GpuClockOffset(pstate) => match value {
+                Some(value) => {
+                    clocks.gpu_clock_offsets.insert(pstate, value);
+                }
+                None => {
+                    clocks.gpu_clock_offsets.shift_remove(&pstate);
+                }
+            },
+            ClockspeedType::MemClockOffset(pstate) => match value {
+                Some(value) => {
+                    clocks.mem_clock_offsets.insert(pstate, value);
+                }
+                None => {
+                    clocks.mem_clock_offsets.shift_remove(&pstate);
+                }
+            },
+            ClockspeedType::Reset => {
+                *clocks = ClocksConfiguration::default();
+                assert!(!self.is_core_clocks_used());
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FanCurve(pub FanCurveMap);
+
+impl Default for FanCurve {
+    fn default() -> Self {
+        Self(default_fan_curve())
+    }
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FanControlSettings {
+    #[serde(default)]
+    pub mode: FanControlMode,
+    #[serde(default = "default_fan_static_speed")]
+    pub static_speed: f32,
+    pub temperature_key: String,
+    pub interval_ms: u64,
+    pub curve: FanCurve,
+    pub spindown_delay_ms: Option<u64>,
+    pub change_threshold: Option<u64>,
+}
+
+impl Default for FanControlSettings {
+    fn default() -> Self {
+        Self {
+            mode: FanControlMode::default(),
+            static_speed: default_fan_static_speed(),
+            temperature_key: "edge".to_owned(),
+            interval_ms: 500,
+            curve: FanCurve(default_fan_curve()),
+            spindown_delay_ms: None,
+            change_threshold: None,
+        }
+    }
+}
+
+pub fn default_fan_static_speed() -> f32 {
+    0.5
+}

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "args")]
 pub mod args;
+pub mod config;
 mod profiles;
 pub mod request;
 mod response;

--- a/lact-schema/src/request.rs
+++ b/lact-schema/src/request.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{FanOptions, ProfileRule};
+use crate::{config::GpuConfig, FanOptions, ProfileRule};
 use amdgpu_sysfs::gpu_handle::{PerformanceLevel, PowerLevelKind};
 use serde::{Deserialize, Serialize};
 
@@ -88,6 +88,10 @@ pub enum Request<'a> {
     },
     GetGpuConfig {
         id: &'a str,
+    },
+    SetGpuConfig {
+        id: &'a str,
+        config: GpuConfig,
     },
     EnableOverdrive,
     DisableOverdrive,

--- a/lact-schema/src/request.rs
+++ b/lact-schema/src/request.rs
@@ -86,6 +86,9 @@ pub enum Request<'a> {
         name: String,
         rule: Option<ProfileRule>,
     },
+    GetGpuConfig {
+        id: &'a str,
+    },
     EnableOverdrive,
     DisableOverdrive,
     GenerateSnapshot,


### PR DESCRIPTION
Instead of having various `set_` API requests for different options, there is now a pair of `GetGpuConfig`/`SetGpuConfig` calls which send the whole GPU config over. This simplifies the API and also solidifies the config format as the single schema instead of having separate structs for different calls.

This also has a consequence of the UI applying all the settings in a single API request, and the confirmation dialog will now revert non-clocks related settings as well if not confirmed.

Old API calls are kept for compatibility.