### PR TITLE
chore: put the OC page stats into a FlowBox, hide unavailable stats

### DIFF
--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -1,5 +1,6 @@
 mod apply_revealer;
 mod confirmation_dialog;
+mod ext;
 pub mod graphs_window;
 mod header;
 mod info_row;

--- a/lact-gui/src/app/ext.rs
+++ b/lact-gui/src/app/ext.rs
@@ -1,0 +1,19 @@
+use gtk::{
+    glib::object::{Cast, IsA},
+    prelude::WidgetExt,
+    FlowBox, FlowBoxChild, Widget,
+};
+
+pub trait FlowBoxExt {
+    fn append_child(&self, child: &impl IsA<Widget>) -> FlowBoxChild;
+}
+
+impl FlowBoxExt for FlowBox {
+    fn append_child(&self, child: &impl IsA<Widget>) -> FlowBoxChild {
+        self.append(child);
+        self.last_child()
+            .unwrap()
+            .downcast::<FlowBoxChild>()
+            .unwrap()
+    }
+}


### PR DESCRIPTION
Normal:
![image](https://github.com/user-attachments/assets/a9a3e5d4-8d36-47eb-bd0d-bad0cb8bbfee)

Stretched window:
![image](https://github.com/user-attachments/assets/a2b92fc2-3907-4e95-8292-a30f980533af)

Intel iGPU with few stats:
![image](https://github.com/user-attachments/assets/674a9f6a-dcff-43e4-8ce2-49fad78e35e7)
