### PR TITLE
feat: zero RPM support on nvidia via automatic fan mode threshold temp

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -82,6 +82,9 @@ gpus:
       # to affect the fan speed. Also used to avoid rapid fan speed changes
       # when the temperature only changes e.g. 1 degree.
       change_threshold: 0
+      # A temperature below which the fan control mode is switched to automatic (Nvidia only)
+      # This can be used as a workaround to achieve 0 RPM below a certain temperature even when the GPU only allows speeds like 30-100% to be set manually.
+      auto_threshold: 0
     # Power management firmware options. Specific to RDNA3+ AMD GPUs.
     # Most of these settings are only applied when not using a custom fan curve.
     pmfw_options: 

--- a/lact-daemon/src/config.rs
+++ b/lact-daemon/src/config.rs
@@ -418,6 +418,7 @@ mod tests {
                         static_speed: 0.5,
                         spindown_delay_ms: Some(5000),
                         change_threshold: Some(3),
+                        auto_threshold: Some(40),
                     }),
                     ..Default::default()
                 },

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -652,6 +652,7 @@ impl GpuController for AmdGpuController {
                 curve: fan_settings.map(|settings| settings.curve.0.clone()),
                 spindown_delay_ms: fan_settings.and_then(|settings| settings.spindown_delay_ms),
                 change_threshold: fan_settings.and_then(|settings| settings.change_threshold),
+                auto_threshold: None,
                 speed_current: self.hw_mon_and_then(HwMon::get_fan_current).or_else(|| {
                     metrics
                         .and_then(MetricsInfo::get_current_fan_speed)

--- a/lact-daemon/src/snapshots/lact_daemon__config__tests__parse_doc.snap
+++ b/lact-daemon/src/snapshots/lact_daemon__config__tests__parse_doc.snap
@@ -26,6 +26,7 @@ gpus:
         80: 1
       spindown_delay_ms: 0
       change_threshold: 0
+      auto_threshold: 0
     pmfw_options:
       acoustic_limit: 3200
       acoustic_target: 1450

--- a/lact-schema/src/config.rs
+++ b/lact-schema/src/config.rs
@@ -79,17 +79,6 @@ mod offsets {
             })
             .collect()
     }
-
-    /*pub fn serialize<S: Serializer>(
-        offsets: &IndexMap<u32, i32>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error> {
-        let map = offsets
-            .iter()
-            .map(|(key, value)| (key.to_string(), value))
-            .collect::<IndexMap<_, _>>();
-        map.serialize(serializer)
-    }*/
 }
 
 impl GpuConfig {
@@ -153,6 +142,7 @@ pub struct FanControlSettings {
     pub curve: FanCurve,
     pub spindown_delay_ms: Option<u64>,
     pub change_threshold: Option<u64>,
+    pub auto_threshold: Option<u64>,
 }
 
 impl Default for FanControlSettings {
@@ -165,6 +155,7 @@ impl Default for FanControlSettings {
             curve: FanCurve(default_fan_curve()),
             spindown_delay_ms: None,
             change_threshold: None,
+            auto_threshold: None,
         }
     }
 }

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -479,6 +479,8 @@ pub struct FanStats {
     pub temperature_range: Option<(i32, i32)>,
     pub spindown_delay_ms: Option<u64>,
     pub change_threshold: Option<u64>,
+    /// Nvidia-only
+    pub auto_threshold: Option<u64>,
     // RDNA3+ params
     #[serde(default)]
     pub pmfw_info: PmfwInfo,


### PR DESCRIPTION
This allows zero RPM to be used on Nvidia with a custom fan curve using the same workaround as the FanControl windows application: https://github.com/Rem0o/FanControl.Releases/wiki/Nvidia-30%25-and-0-RPM