### PR TITLE
fix: do not return an error in the middle of a loop

### DIFF
--- a/lact-daemon/src/server/opencl.rs
+++ b/lact-daemon/src/server/opencl.rs
@@ -96,9 +96,12 @@ fn find_matching_device(
                 }
             }
 
-            let raw_bus_info = device::get_device_info(device, CL_DEVICE_PCI_BUS_INFO_KHR)
-                .map_err(|err| anyhow!("Could not get bus info: {err}"))?
-                .to_vec_uchar();
+            let Ok(raw_bus_info) = device::get_device_info(device, CL_DEVICE_PCI_BUS_INFO_KHR)
+                .map_err(|err| anyhow!("Could not get bus info: {err}"))
+                .map(|info_type| info_type.to_vec_uchar())
+            else {
+                continue;
+            };
             let bus_info = device::get_device_pci_bus_info_khr(&raw_bus_info);
 
             if bus_info.pci_bus == u32::from(slot_info.bus)


### PR DESCRIPTION
On the OpenCL driver that do not support `CL_DEVICE_PCI_BUS_INFO_KHR`, such as ROCm, an error will be returned in the middle of the loop, and the OpenCL information for the second and subsequent GPU will not be detected correctly.  
This PR fixes that.  