### PR TITLE
chore: use PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,23 @@ export CARGO_NET_GIT_FETCH_WITH_CLI ?= true
 DESTDIR ?= /
 PREFIX ?= /usr/local
 
+.PHONY: build-release
 build-release:
 	cargo build -p lact --release
 
+.PHONY: build-debug
 build-debug:
 	cargo build -p lact
 	
+.PHONY: build-release-libadwaita
 build-release-libadwaita:
 	cargo build -p lact --release --features=adw
 	
+.PHONY: build-release-headless
 build-release-headless:
 	cargo build -p lact --release --no-default-features
 	
+.PHONY: install-resources
 install-resources:
 	install -Dm644 res/lactd.service $(DESTDIR)$(PREFIX)/lib/systemd/system/lactd.service
 	install -Dm644 res/io.github.ilya_zlobintsev.LACT.desktop $(DESTDIR)$(PREFIX)/share/applications/io.github.ilya_zlobintsev.LACT.desktop
@@ -22,12 +27,15 @@ install-resources:
 	install -Dm644 res/io.github.ilya_zlobintsev.LACT.svg $(DESTDIR)$(PREFIX)/share/icons/hicolor/scalable/apps/io.github.ilya_zlobintsev.LACT.svg
 	install -Dm644 res/io.github.ilya_zlobintsev.LACT.metainfo.xml $(DESTDIR)$(PREFIX)/share/metainfo/io.github.ilya_zlobintsev.LACT.metainfo.xml
 
+.PHONY: install
 install: install-resources
 	install -Dm755 target/release/lact $(DESTDIR)$(PREFIX)/bin/lact
 	
+.PHONY: install-debug
 install-debug: install-resources
 	install -Dm755 target/debug/lact $(DESTDIR)$(PREFIX)/bin/lact
 
+.PHONY: uninstall
 uninstall:
 	rm $(DESTDIR)$(PREFIX)/bin/lact
 	rm $(DESTDIR)$(PREFIX)/lib/systemd/system/lactd.service


### PR DESCRIPTION
```shell
fruzitent@archlinux ~/d/LACT (master)> touch uninstall
fruzitent@archlinux ~/d/LACT (master)> make uninstall
make: 'uninstall' is up to date.
fruzitent@archlinux ~/d/LACT (chore/add-phony)> make uninstall
rm //usr/local/bin/lact
rm: cannot remove '//usr/local/bin/lact': No such file or directory
make: *** [Makefile:40: uninstall] Error 1
```

Ref: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html