### PR TITLE
chore: Nvidia OC UX improvements

### DIFF
--- a/lact-gui/src/app/apply_revealer.rs
+++ b/lact-gui/src/app/apply_revealer.rs
@@ -30,12 +30,16 @@ impl SimpleComponent for ApplyRevealer {
                 gtk::Button {
                     set_label: "Apply",
                     set_hexpand: true,
-                    connect_clicked[sender] => move |_| { sender.output(super::AppMsg::ApplyChanges).unwrap(); },
+                    connect_clicked[sender] => move |_| {
+                        sender.output(super::AppMsg::ApplyChanges).unwrap();
+                    },
                 },
 
                 gtk::Button {
                     set_label: "Revert",
-                    connect_clicked[sender] => move |_| { sender.output(super::AppMsg::RevertChanges).unwrap(); },
+                    connect_clicked[sender] => move |_| {
+                        sender.output(super::AppMsg::RevertChanges).unwrap();
+                    },
                 },
             }
         }


### PR DESCRIPTION
- Add a note explaining what the options do and their limitations. This should help avoid confusion by users with behaviour such as #602. It also mentions the psuedo-undervolting added in #486.
- The "Show all P-States" toggle no longer gets reset when applying settings