### PR TITLE
feat: store plot configs per-gpu

### DIFF
--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -424,7 +424,7 @@ impl AppModel {
                 });
                 self.graphs_window.emit(GraphsWindowMsg::Stats {
                     stats,
-                    initial: false,
+                    selected_gpu_id: None,
                 });
             }
             AppMsg::ApplyChanges => {
@@ -617,11 +617,11 @@ impl AppModel {
         self.graphs_window
             .emit(GraphsWindowMsg::VramClockRatio(vram_clock_ratio));
 
-        let stats = self.update_gpu_data(gpu_id, sender).await?;
+        let stats = self.update_gpu_data(gpu_id.clone(), sender).await?;
 
         self.graphs_window.emit(GraphsWindowMsg::Stats {
             stats,
-            initial: true,
+            selected_gpu_id: Some(gpu_id),
         });
 
         self.ui_sensitive.set_value(true);

--- a/lact-gui/src/app/graphs_window/mod.rs
+++ b/lact-gui/src/app/graphs_window/mod.rs
@@ -27,6 +27,7 @@ use std::{
 
 pub struct GraphsWindow {
     time_period_seconds_adj: gtk::Adjustment,
+    gpu_id: Option<String>,
     edit_mode: BoolBinding,
     plots_per_row: F64Binding,
     vram_clock_ratio: f64,
@@ -38,7 +39,8 @@ pub struct GraphsWindow {
 pub enum GraphsWindowMsg {
     Stats {
         stats: Arc<DeviceStats>,
-        initial: bool,
+        /// Fill for initial message
+        selected_gpu_id: Option<String>,
     },
     VramClockRatio(f64),
     NotifyEditing,
@@ -171,6 +173,7 @@ impl relm4::Component for GraphsWindow {
             plots_per_row,
             edit_mode,
             plots,
+            gpu_id: None,
             vram_clock_ratio: 1.0,
             stats_data,
         };
@@ -195,17 +198,22 @@ impl relm4::Component for GraphsWindow {
             GraphsWindowMsg::VramClockRatio(ratio) => {
                 self.vram_clock_ratio = ratio;
             }
-            GraphsWindowMsg::Stats { stats, initial } => {
-                if initial {
+            GraphsWindowMsg::Stats {
+                stats,
+                selected_gpu_id,
+            } => {
+                if let Some(selected_gpu_id) = selected_gpu_id {
                     self.stats_data.write().unwrap().clear();
 
                     let config = CONFIG.read();
-                    let plots_config = if config.plots.is_empty() {
-                        default_plots()
-                    } else {
-                        config.plots.clone()
-                    };
+                    let plots_config = config
+                        .gpus
+                        .get(&selected_gpu_id)
+                        .map(|config| config.plots.clone())
+                        .filter(|plots| !plots.is_empty())
+                        .unwrap_or_else(default_plots);
 
+                    self.gpu_id = Some(selected_gpu_id);
                     sender.input(GraphsWindowMsg::SetConfig(plots_config));
                 }
 
@@ -257,16 +265,19 @@ impl relm4::Component for GraphsWindow {
                 sender.input(GraphsWindowMsg::SaveConfig);
             }
             GraphsWindowMsg::SaveConfig => {
-                CONFIG.write().edit(|config| {
-                    config.plots = self
-                        .plots
-                        .iter()
-                        .map(|plot| plot.selected_stats())
-                        .collect();
+                if let Some(gpu_id) = self.gpu_id.clone() {
+                    CONFIG.write().edit(|config| {
+                        config.gpus.entry(gpu_id).or_default().plots = self
+                            .plots
+                            .iter()
+                            .map(|plot| plot.selected_stats())
+                            .collect();
 
-                    config.plots_time_period = Some(self.time_period_seconds_adj.value() as u64);
-                    config.plots_per_row = Some(self.plots_per_row.value() as u64);
-                });
+                        config.plots_time_period =
+                            Some(self.time_period_seconds_adj.value() as u64);
+                        config.plots_per_row = Some(self.plots_per_row.value() as u64);
+                    });
+                }
             }
             GraphsWindowMsg::ExportData => {
                 let settings = SaveDialogSettings {

--- a/lact-gui/src/config.rs
+++ b/lact-gui/src/config.rs
@@ -1,6 +1,6 @@
 use crate::app::graphs_window::stat::StatType;
 use serde::{Deserialize, Serialize};
-use std::{env, fs, path::PathBuf};
+use std::{collections::HashMap, env, fs, path::PathBuf};
 use tracing::{debug, error};
 
 #[derive(Default, Serialize, Deserialize)]
@@ -11,6 +11,12 @@ pub struct UiConfig {
     pub plots_time_period: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plots_per_row: Option<u64>,
+    #[serde(default)]
+    pub gpus: HashMap<String, UiGpuConfig>,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct UiGpuConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub plots: Vec<Vec<StatType>>,
 }


### PR DESCRIPTION
Previously the plots were configured globally for all GPUs, which lead to stats which are present on one GPU but not the other to get removed from the plot when switching GPUs. Now the plots are stored per-GPU, which avoids the issue.

Note: this will reset existing custom plot configs.