### PR TITLE
feat: run socket chown as a host command from flatbox to work around apparmor restrictions

### DIFF
--- a/lact-daemon/src/server.rs
+++ b/lact-daemon/src/server.rs
@@ -42,7 +42,12 @@ impl Server {
 
         let handler = Handler::new(config).await?;
 
-        socket::set_permissions(&socket_path, &handler.config.read().await.daemon)?;
+        socket::set_permissions(&socket_path, &handler.config.read().await.daemon)
+            .await
+            .inspect_err(|_| {
+                // Clean up the socket if permissions failed to be set
+                socket::cleanup();
+            })?;
 
         Ok(Self {
             handler,

--- a/lact-daemon/src/socket.rs
+++ b/lact-daemon/src/socket.rs
@@ -11,7 +11,10 @@ use std::{
 use tokio::net::UnixListener;
 use tracing::{debug, info};
 
-use crate::config;
+use crate::{
+    config,
+    system::{run_command, IS_FLATBOX},
+};
 
 pub fn get_socket_path() -> PathBuf {
     let uid = getuid();
@@ -54,7 +57,10 @@ pub fn listen() -> anyhow::Result<(UnixListener, PathBuf)> {
     Ok((listener, socket_path))
 }
 
-pub fn set_permissions(socket_path: &Path, daemon_config: &config::Daemon) -> anyhow::Result<()> {
+pub async fn set_permissions(
+    socket_path: &Path,
+    daemon_config: &config::Daemon,
+) -> anyhow::Result<()> {
     let group = daemon_config
         .admin_group
         .as_ref()
@@ -79,7 +85,23 @@ pub fn set_permissions(socket_path: &Path, daemon_config: &config::Daemon) -> an
 
     debug!("using gid {group} uid {user:?} for socket");
 
-    chown(socket_path, user, Some(group)).context("Could not set socket permissions")?;
+    if *IS_FLATBOX {
+        let owner_arg = match user {
+            Some(user) => format!("{}:{}", user.as_raw(), group.as_raw()),
+            None => format!(":{}", group.as_raw()),
+        };
+
+        let path = socket_path
+            .to_str()
+            .expect("Invalid socket path")
+            .trim_start_matches("/run/host/root");
+
+        run_command("chown", &[&owner_arg, path])
+            .await
+            .context("Could not set socket permissions")?;
+    } else {
+        chown(socket_path, user, Some(group)).context("Could not set socket permissions")?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #647 