### PR TITLE
feat: expose full V/F curve for GCN and RDNA1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amdgpu-sysfs"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92cb961b34a3719d5a89044104e8f4eb8278eb1af831be31ea4c8b7b08265db"
+checksum = "e5fbcdced7a84f93ddaf2f038b299853ea57c2a436c79644b88462838b6bcef3"
 dependencies = [
  "enum_dispatch",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.dependencies]
-amdgpu-sysfs = { version = "0.19.0", features = ["serde"] }
+amdgpu-sysfs = { version = "0.19.1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "3.5.0", default-features = false, features = [
     "macros",

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -173,6 +173,18 @@ gpus:
     max_voltage: 1200
     # Voltage offset value in mV for RDNA and newer AMD GPUs.
     voltage_offset: 0
+
+    # GPU V/F curve with voltage and frequency points per each power state.
+    # Applicable only to AMD GCN and RDNA1 GPUs. Overrides the values of min/max clock/voltage fields.
+    gpu_vf_curve:
+      7:
+        clockspeed: 1590
+        voltage: 1200
+    # VRAM V/F curve with voltage and frequency points per each power state.
+    # Applicable only to AMD GCN GPUs. Overrides the values of min/max memory clock fields.
+    mem_vf_curve:
+      3:
+        clockspeed: 920
     
     # GPU and VRAM clockspeed offset values, per-pstate. Applicable on Nvidia and on AMD RDNA4.
     gpu_clock_offsets:

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -1239,7 +1239,7 @@ fn apply_clocks_config_to_table(
 
             #[allow(clippy::cast_possible_truncation)]
             if let Some(max_clock) = config.gpu_vf_curve.get(&(table.vddc_curve.len() as u8 - 1)) {
-                table.current_sclk_range.min = max_clock.clockspeed;
+                table.current_sclk_range.max = max_clock.clockspeed;
             }
         }
     }

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -18,7 +18,7 @@ use amdgpu_sysfs::{
     hw_mon::{FanControlMethod, HwMon},
     sysfs::SysFS,
 };
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, bail, Context};
 use futures::{future::LocalBoxFuture, FutureExt};
 use lact_schema::{
     config::{ClocksConfiguration, FanControlSettings, FanCurve, GpuConfig},
@@ -1171,6 +1171,118 @@ fn apply_clocks_config_to_table(
     }
     if let Some(voltage) = config.max_voltage {
         table.set_max_voltage(voltage)?;
+    }
+
+    if !config.gpu_vf_curve.is_empty() {
+        // Validate first
+        for (i, point) in &config.gpu_vf_curve {
+            if let Some(clockspeed) = point.clockspeed {
+                let range = match table {
+                    ClocksTableGen::Gcn(table) => table.od_range.sclk,
+                    ClocksTableGen::Rdna(table) => table
+                        .od_range
+                        .curve_sclk_points
+                        .get(*i as usize)
+                        .copied()
+                        .unwrap_or_default(),
+                };
+                let (min, max) = range.into_full().context("SCLK range not present")?;
+
+                if !(min..=max).contains(&clockspeed) {
+                    bail!("Clockspeed {clockspeed} is not in the allowed range {min}-{max}");
+                }
+            }
+
+            if let Some(voltage) = point.voltage {
+                let range = match table {
+                    ClocksTableGen::Gcn(table) => table.od_range.vddc,
+                    ClocksTableGen::Rdna(table) => table
+                        .od_range
+                        .curve_voltage_points
+                        .get(*i as usize)
+                        .copied(),
+                };
+                let (min, max) = range
+                    .unwrap_or_default()
+                    .into_full()
+                    .context("Voltage range not present")?;
+
+                if !(min..=max).contains(&voltage) {
+                    bail!("Voltage {voltage} is not in the allowed range {min}-{max}");
+                }
+            }
+        }
+
+        let points = match table {
+            ClocksTableGen::Gcn(table) => &mut table.sclk_levels,
+            ClocksTableGen::Rdna(table) => &mut table.vddc_curve,
+        };
+        for (i, point) in &config.gpu_vf_curve {
+            let level = points
+                .get_mut(*i as usize)
+                .with_context(|| format!("GPU does not have a p-state {i}"))?;
+
+            if let Some(clockspeed) = point.clockspeed {
+                level.clockspeed = clockspeed;
+            }
+
+            if let Some(voltage) = point.voltage {
+                level.voltage = voltage;
+            }
+        }
+    }
+
+    if !config.mem_vf_curve.is_empty() {
+        match table {
+            ClocksTableGen::Gcn(table) => {
+                // Validate first
+                for (_, point) in &config.mem_vf_curve {
+                    if let Some(clockspeed) = point.clockspeed {
+                        let (min, max) = table
+                            .od_range
+                            .mclk
+                            .unwrap_or_default()
+                            .into_full()
+                            .context("MCLK range not present")?;
+
+                        if !(min..=max).contains(&clockspeed) {
+                            bail!(
+                                "Memory clockspeed {clockspeed} is not in the allowed range {min}-{max}"
+                            );
+                        }
+                    }
+
+                    if let Some(voltage) = point.voltage {
+                        let (min, max) = table
+                            .od_range
+                            .vddc
+                            .unwrap_or_default()
+                            .into_full()
+                            .context("Voltage range not present")?;
+
+                        if !(min..=max).contains(&voltage) {
+                            bail!("Voltage {voltage} is not in the allowed range {min}-{max}");
+                        }
+                    }
+                }
+
+                for (i, point) in &config.mem_vf_curve {
+                    let level = table
+                        .mclk_levels
+                        .get_mut(*i as usize)
+                        .with_context(|| format!("GPU does not have a p-state {i}"))?;
+
+                    if let Some(clockspeed) = point.clockspeed {
+                        level.clockspeed = clockspeed;
+                    }
+
+                    if let Some(voltage) = point.voltage {
+                        level.voltage = voltage;
+                    }
+                }
+            }
+            ClocksTableGen::Rdna(_) => bail!("VRAM VF curve not supported"),
+        };
     }
 
     Ok(())

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -1230,6 +1230,18 @@ fn apply_clocks_config_to_table(
                 level.voltage = voltage;
             }
         }
+
+        // Apply RDNA1 OD_SCLK options in addition to the vddc curve
+        if let ClocksTableGen::Rdna(table) = table {
+            if let Some(min_clock) = config.gpu_vf_curve.get(&0) {
+                table.current_sclk_range.min = min_clock.clockspeed;
+            }
+
+            #[allow(clippy::cast_possible_truncation)]
+            if let Some(max_clock) = config.gpu_vf_curve.get(&(table.vddc_curve.len() as u8 - 1)) {
+                table.current_sclk_range.min = max_clock.clockspeed;
+            }
+        }
     }
 
     if !config.mem_vf_curve.is_empty() {

--- a/lact-daemon/src/snapshots/lact_daemon__config__tests__parse_doc.snap
+++ b/lact-daemon/src/snapshots/lact_daemon__config__tests__parse_doc.snap
@@ -47,6 +47,13 @@ gpus:
       0: -100
     mem_clock_offsets:
       0: 200
+    gpu_vf_curve:
+      7:
+        voltage: 1200
+        clockspeed: 1590
+    mem_vf_curve:
+      3:
+        clockspeed: 920
     voltage_offset: 0
     power_profile_mode_index: 0
     custom_power_profile_mode_hueristics:

--- a/lact-daemon/src/tests/data/amd/rx5500xt/config.yaml
+++ b/lact-daemon/src/tests/data/amd/rx5500xt/config.yaml
@@ -1,1 +1,5 @@
 max_core_clock: 2000
+gpu_vf_curve:
+  2:
+    clockspeed: 1950
+    voltage: 1102

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__apply_config__amd__rx5500xt.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__apply_config__amd__rx5500xt.snap
@@ -4,9 +4,9 @@ expression: write_commands
 ---
 [
     "card1/device/pp_od_clk_voltage: r\n",
-    "card1/device/pp_od_clk_voltage: s 1 2000\n",
+    "card1/device/pp_od_clk_voltage: s 1 1950\n",
     "card1/device/pp_od_clk_voltage: vc 0 800 736\n",
     "card1/device/pp_od_clk_voltage: vc 1 1200 779\n",
-    "card1/device/pp_od_clk_voltage: vc 2 2000 1102\n",
+    "card1/device/pp_od_clk_voltage: vc 2 1950 1102\n",
     "card1/device/pp_od_clk_voltage: c\n",
 ]

--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -121,6 +121,10 @@ min-gpu-voltage = Minimum GPU Voltage (mV)
 gpu-voltage-offset = GPU voltage offset (mV)
 gpu-pstate-clock-offset = GPU P-State {$pstate} Clock Offset (MHz)
 vram-pstate-clock-offset = VRAM P-State {$pstate} Clock Offset (MHz)
+gpu-pstate-clock = GPU P-State {$pstate} Clock (MHz)
+mem-pstate-clock = VRAM P-State {$pstate} Clock (MHz)
+gpu-pstate-clock-voltage = GPU P-State {$pstate} Voltage (mV)
+mem-pstate-clock-voltage = VRAM P-State {$pstate} Voltage (mV)
 
 pstates = Power States
 gpu-pstates = GPU Power States

--- a/lact-gui/src/app/pages/oc_page/clocks_frame.rs
+++ b/lact-gui/src/app/pages/oc_page/clocks_frame.rs
@@ -310,7 +310,9 @@ impl ClocksFrame {
                     );
                 }
 
-                if let Some((min_mclk, max_mclk)) = table.od_range.sclk.into_full() {
+                if let Some((min_mclk, max_mclk)) =
+                    table.od_range.mclk.and_then(|range| range.into_full())
+                {
                     self.add_amd_list(
                         table.mclk_levels.iter().map(|level| level.clockspeed),
                         ClockspeedType::MemVfCurveClock,

--- a/lact-gui/src/app/pages/oc_page/clocks_frame/adjustment_row.rs
+++ b/lact-gui/src/app/pages/oc_page/clocks_frame/adjustment_row.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use gtk::{
     glib::{object::ObjectExt, SignalHandlerId},
-    prelude::{AdjustmentExt, BoxExt, OrientableExt, RangeExt, ScaleExt, WidgetExt},
+    prelude::{AdjustmentExt, OrientableExt, RangeExt, ScaleExt, WidgetExt},
 };
 use i18n_embed_fl::fl;
 use lact_schema::request::ClockspeedType;
@@ -65,10 +65,10 @@ impl FactoryComponent for ClockAdjustmentRow {
         #[name = "root_box"]
         gtk::Box {
             set_orientation: gtk::Orientation::Vertical,
-            set_spacing: 10,
 
             gtk::Separator {
                 set_visible: self.show_separator,
+                set_margin_vertical: 10,
             },
 
             gtk::Box {

--- a/lact-schema/src/config.rs
+++ b/lact-schema/src/config.rs
@@ -88,6 +88,7 @@ pub struct ClocksConfiguration {
     pub voltage_offset: Option<i32>,
 }
 
+#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct CurvePoint {
     pub voltage: Option<i32>,

--- a/lact-schema/src/config.rs
+++ b/lact-schema/src/config.rs
@@ -73,7 +73,17 @@ pub struct ClocksConfiguration {
         deserialize_with = "offsets::deserialize"
     )]
     pub mem_clock_offsets: IndexMap<u32, i32>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub gpu_vf_curve: IndexMap<u8, CurvePoint>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub mem_vf_curve: IndexMap<u8, CurvePoint>,
     pub voltage_offset: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct CurvePoint {
+    pub voltage: Option<i32>,
+    pub clockspeed: Option<i32>,
 }
 
 mod offsets {
@@ -136,6 +146,18 @@ impl GpuConfig {
                     clocks.mem_clock_offsets.shift_remove(&pstate);
                 }
             },
+            ClockspeedType::GpuVfCurveClock(point) => {
+                clocks.gpu_vf_curve.entry(point).or_default().clockspeed = value;
+            }
+            ClockspeedType::GpuVfCurveVoltage(point) => {
+                clocks.gpu_vf_curve.entry(point).or_default().voltage = value;
+            }
+            ClockspeedType::MemVfCurveClock(point) => {
+                clocks.mem_vf_curve.entry(point).or_default().clockspeed = value;
+            }
+            ClockspeedType::MemVfCurveVoltage(point) => {
+                clocks.mem_vf_curve.entry(point).or_default().voltage = value;
+            }
             ClockspeedType::Reset => {
                 *clocks = ClocksConfiguration::default();
                 assert!(!self.is_core_clocks_used());

--- a/lact-schema/src/request.rs
+++ b/lact-schema/src/request.rs
@@ -145,6 +145,10 @@ pub enum ClockspeedType {
     VoltageOffset,
     GpuClockOffset(u32),
     MemClockOffset(u32),
+    GpuVfCurveClock(u8),
+    MemVfCurveClock(u8),
+    GpuVfCurveVoltage(u8),
+    MemVfCurveVoltage(u8),
     Reset,
 }
 


### PR DESCRIPTION
Previously these GPUs only supported configuring the min/max values as a remnant of the UI originally being static and identical for any GPU. There is no longer such a limitation as the UI was reworked to be more dynamic for Nvidia, so full curves can now be exposed:
<img width="848" height="749" alt="image" src="https://github.com/user-attachments/assets/bb3fcf25-0059-4b0b-a2e9-0782e0eb4138" />
