### PR TITLE
Uppercase BAR

### DIFF
--- a/lact-schema/i18n/en/lact_schema.ftl
+++ b/lact-schema/i18n/en/lact_schema.ftl
@@ -16,7 +16,7 @@ isa = Instruction Set
 l1-cache-per-cu = L1 Cache (Per CU)
 l2-cache = L2 Cache
 l3-cache = L3 Cache
-rebar = Resizable Bar
+rebar = Resizable BAR
 cpu-vram = CPU Accessible VRAM
 pcie-speed = PCIe Link Speed
 


### PR DESCRIPTION
AFAIK it means [Base Address Register](https://www.intel.com/content/www/us/en/support/articles/000090831/graphics.html), so it makes sense making this acronym uppercase.

I'm most worried that translators might think is bar is a word like crowbar and translate it incorrectly.