### PR TITLE
feat: detect device features on the daemon side, disable more ui elements for what's not supported

### DIFF
--- a/lact-daemon/src/lib.rs
+++ b/lact-daemon/src/lib.rs
@@ -28,9 +28,6 @@ use tracing::level_filters::LevelFilter;
 use tracing::{debug, debug_span, error, info, warn, Instrument};
 use tracing_subscriber::EnvFilter;
 
-/// RDNA3, minimum family that supports the new pmfw interface
-pub const AMDGPU_FAMILY_GC_11_0_0: u32 = 145;
-
 pub use system::BASE_MODULE_CONF_PATH;
 
 const MIN_SYSTEM_UPTIME_SECS: f32 = 15.0;

--- a/lact-daemon/src/server/gpu_controller/intel.rs
+++ b/lact-daemon/src/server/gpu_controller/intel.rs
@@ -620,6 +620,7 @@ impl GpuController for IntelGpuController {
                 link_info: LinkInfo::default(),
                 drm_info: Some(drm_info),
                 opencl_info: get_opencl_info(&self.common),
+                flags: vec![],
             }
         })
     }

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -17,10 +17,10 @@ use futures::{future::LocalBoxFuture, FutureExt};
 use indexmap::IndexMap;
 use lact_schema::{
     config::{FanControlSettings, FanCurve, GpuConfig},
-    CacheInfo, ClocksInfo, ClocksTable, ClockspeedStats, DeviceInfo, DeviceStats, DeviceType,
-    DrmInfo, DrmMemoryInfo, FanControlMode, FanStats, IntelDrmInfo, LinkInfo, NvidiaClockOffset,
-    NvidiaClocksTable, PmfwInfo, PowerState, PowerStates, PowerStats, ProcessInfo, ProcessList,
-    ProcessType, ProcessUtilizationType, VoltageStats, VramStats,
+    CacheInfo, ClocksInfo, ClocksTable, ClockspeedStats, DeviceFlag, DeviceInfo, DeviceStats,
+    DeviceType, DrmInfo, DrmMemoryInfo, FanControlMode, FanStats, IntelDrmInfo, LinkInfo,
+    NvidiaClockOffset, NvidiaClocksTable, PmfwInfo, PowerState, PowerStates, PowerStats,
+    ProcessInfo, ProcessList, ProcessType, ProcessUtilizationType, VoltageStats, VramStats,
 };
 use nvml_wrapper::{
     bitmasks::device::ThrottleReasons,
@@ -451,6 +451,10 @@ impl GpuController for NvidiaGpuController {
                         .ok(),
                     intel: IntelDrmInfo::default(),
                 }),
+                flags: vec![
+                    DeviceFlag::ConfigurableFanControl,
+                    DeviceFlag::AutoFanThreshold,
+                ],
             }
         })
     }

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__hd7870.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__hd7870.snap
@@ -9,6 +9,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "8.0 GT/s PCIe",
       "current_width": "1"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__r9-280.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__r9-280.snap
@@ -9,6 +9,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "5.0 GT/s PCIe",
       "current_width": "8"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx5500xt.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx5500xt.snap
@@ -85,6 +85,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "16.0 GT/s PCIe",
       "current_width": "16"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx5700xt.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx5700xt.snap
@@ -85,6 +85,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "16.0 GT/s PCIe",
       "current_width": "16"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx580.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx580.snap
@@ -83,6 +83,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "max_speed": "8.0 GT/s PCIe",
       "max_width": "16"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx6600.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx6600.snap
@@ -45,6 +45,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "16.0 GT/s PCIe",
       "current_width": "16"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx6600xt.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx6600xt.snap
@@ -9,6 +9,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "16.0 GT/s PCIe",
       "current_width": "16"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx6900xt.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx6900xt.snap
@@ -45,6 +45,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "16.0 GT/s PCIe",
       "current_width": "16",

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx7600s.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx7600s.snap
@@ -9,6 +9,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "16.0 GT/s PCIe",
       "current_width": "8"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx7700s.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx7700s.snap
@@ -9,6 +9,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "16.0 GT/s PCIe",
       "current_width": "8"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx7800xt.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx7800xt.snap
@@ -48,6 +48,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "16.0 GT/s PCIe",
       "current_width": "16"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx7900xtx.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx7900xtx.snap
@@ -48,6 +48,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "16.0 GT/s PCIe",
       "current_width": "16"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx9070.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx9070.snap
@@ -47,6 +47,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "32.0 GT/s PCIe",
       "current_width": "16"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx9070xt.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__rx9070xt.snap
@@ -47,6 +47,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "32.0 GT/s PCIe",
       "current_width": "16"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__vangogh.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__vangogh.snap
@@ -68,6 +68,9 @@ expression: device_info
       },
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios"
+    ],
     "link_info": {
       "current_speed": "8.0 GT/s PCIe",
       "current_width": "16"

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__vega56.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__amd__vega56.snap
@@ -87,6 +87,10 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios",
+      "ConfigurableFanControl"
+    ],
     "link_info": {
       "current_speed": "8.0 GT/s PCIe",
       "current_width": "16",

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__a380-i915.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__a380-i915.snap
@@ -27,6 +27,7 @@ expression: device_info
       },
       "vram_clock_ratio": 1.0
     },
+    "flags": [],
     "link_info": {},
     "pci_info": {
       "device_pci_info": {

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__a380-xe.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__a380-xe.snap
@@ -27,6 +27,7 @@ expression: device_info
       },
       "vram_clock_ratio": 1.0
     },
+    "flags": [],
     "link_info": {},
     "pci_info": {
       "device_pci_info": {

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__b580-6.16.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__b580-6.16.snap
@@ -27,6 +27,7 @@ expression: device_info
       },
       "vram_clock_ratio": 1.0
     },
+    "flags": [],
     "link_info": {},
     "pci_info": {
       "device_pci_info": {

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__b580.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__b580.snap
@@ -27,6 +27,7 @@ expression: device_info
       },
       "vram_clock_ratio": 1.0
     },
+    "flags": [],
     "link_info": {},
     "pci_info": {
       "device_pci_info": {

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__cometlake.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__cometlake.snap
@@ -27,6 +27,7 @@ expression: device_info
       },
       "vram_clock_ratio": 1.0
     },
+    "flags": [],
     "link_info": {},
     "pci_info": {
       "device_pci_info": {

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__tigerlake.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__intel__tigerlake.snap
@@ -27,6 +27,7 @@ expression: device_info
       },
       "vram_clock_ratio": 1.0
     },
+    "flags": [],
     "link_info": {},
     "pci_info": {
       "device_pci_info": {

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__nvidia__rtx4080.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__nvidia__rtx4080.snap
@@ -9,6 +9,9 @@ expression: device_info
     "drm_info": {
       "vram_clock_ratio": 1.0
     },
+    "flags": [
+      "DumpableVBios"
+    ],
     "link_info": {
       "current_speed": "5.0 GT/s PCIe",
       "current_width": "16"

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -229,7 +229,7 @@ impl AsyncComponent for AppModel {
         let overdrive_dialog = OverdriveDialog::builder()
             .transient_for(&root)
             .launch(OverdriveDialog {
-                system_info,
+                system_info: system_info.clone(),
                 is_loading: false,
                 is_done: false,
             })
@@ -243,7 +243,7 @@ impl AsyncComponent for AppModel {
                     .downcast::<gtk::HeaderBar>()
                     .unwrap();
             })
-            .launch(devices)
+            .launch((devices, system_info))
             .forward(sender.input_sender(), |msg| msg);
 
         let apply_revealer = ApplyRevealer::builder()
@@ -674,6 +674,7 @@ impl AppModel {
         });
         self.software_page
             .emit(SoftwarePageMsg::DeviceInfo(info.clone()));
+        self.header.emit(HeaderMsg::DeviceInfo(info.clone()));
         self.thermals_page.emit(ThermalsPageMsg::Update {
             update: update.clone(),
             initial: true,

--- a/lact-gui/src/app/pages/thermals_page.rs
+++ b/lact-gui/src/app/pages/thermals_page.rs
@@ -135,7 +135,7 @@ impl relm4::Component for ThermalsPage {
                 PageSection::new(&fl!(I18N, "fan-control-section")) {
                     // Disable fan configuration when overdrive is disabled on GPUs that have PMFW (RDNA3+)
                     #[watch]
-                    set_sensitive: model.fan_speed.is_some() && !(model.system_info.amdgpu_overdrive_enabled == Some(false) && model.has_pmfw),
+                    set_sensitive: model.custom_control_supported,
 
                     append = &gtk::StackSwitcher {
                         set_stack: Some(&stack),

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -117,6 +117,14 @@ pub struct GpuPciInfo {
     pub subsystem_pci_info: PciInfo,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum DeviceFlag {
+    ConfigurableFanControl,
+    DumpableVBios,
+    HasPmfw,
+    AutoFanThreshold,
+}
+
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DeviceInfo {
@@ -128,6 +136,8 @@ pub struct DeviceInfo {
     pub vbios_version: Option<String>,
     pub link_info: LinkInfo,
     pub drm_info: Option<DrmInfo>,
+    #[serde(default)]
+    pub flags: Vec<DeviceFlag>,
 }
 
 impl DeviceInfo {


### PR DESCRIPTION
This hides unavailable functionality more reliably, e.g. VBIOS dumping will be greyed out on Nvidia, and custom fan control will be greyed out on Intel.