### PR TITLE
fix: set min width for thermals input

### DIFF
--- a/lact-gui/src/app/pages/thermals_page.rs
+++ b/lact-gui/src/app/pages/thermals_page.rs
@@ -605,7 +605,9 @@ impl relm4::WidgetTemplate for FanSettingRow {
             },
 
             #[name = "spinbutton"]
-            gtk::SpinButton {},
+            gtk::SpinButton {
+                set_width_request: 120,
+            },
         },
     }
 }


### PR DESCRIPTION
before
<img width="1630" height="928" alt="image" src="https://github.com/user-attachments/assets/e32359eb-a12d-4a58-b9e6-6ec436418969" />
after
<img width="1556" height="880" alt="image" src="https://github.com/user-attachments/assets/8c4558fa-73d7-4aa2-ab3e-086c89320426" />
