### PR TITLE
feat(cli): add profile info and -switcher to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,35 @@ There is also a cli available.
   CPU Accessible VRAM: 16384
   Link Speed: 8 GT/s PCIe gen 3 x8
   ```
+- List profiles:
+
+  `lact cli list-profiles`
+
+  Example output:
+
+  ```
+  Gaming
+  Performance
+  Balanced
+  ```
+- Get current Profile:
+
+  `lact cli current-profile`
+
+  Example output:
+
+  ```
+  Gaming
+  ```
+- Set Profile:
+
+  `lact cli set-profile --name "Performance" --auto-switch "false"`
+
+  Example output:
+
+  ```
+  Performance
+  ```
 
 The functionality of the CLI is quite limited. If you want to integrate LACT
 with some application/script, you should use the [API](API.md) instead.

--- a/lact-schema/src/args.rs
+++ b/lact-schema/src/args.rs
@@ -44,4 +44,18 @@ pub enum CliCommand {
     Info,
     /// Generate debug snapshot
     Snapshot,
+    /// List profiles
+    ListProfiles,
+    /// Current profile
+    CurrentProfile,
+    /// Set profile
+    SetProfile(SetProfileArgs),
+}
+
+#[derive(Parser)]
+pub struct SetProfileArgs {
+    #[arg(short, long, required = true)]
+    pub name: Option<String>,
+    #[arg(short, long, required = true)]
+    pub auto_switch: Option<bool>,
 }


### PR DESCRIPTION
I currently have a script for automatic switching profiles via `lactd.socket`.

This however requires some dependencies like `ncat` and `jq`. Since I'm on an immutable OS where not all of these dependencies are available by default I would think that this could be done with just the LACT cli. So I did a check, and all the methods for this are already implemented so they only had to be mapped to cli.

This PR should make it a great deal easier to have script change profiles (without external deps).

Something like this is currently needed to get the current profile:
```sh
echo "{\"command\": \"list_profiles\", \"args\": {\"include_state\": true }}" | ncat -U /run/lactd.sock | jq -r .data.current_profile
```
This can now be done with:
```sh
lact cli current-profile
# Or flatpak
flatpak run io.github.ilya_zlobintsev.LACT cli current-profile
```
**Spec**
```sh
Usage: lact cli [OPTIONS] <COMMAND>

Commands:
  list-gpus        List GPUs
  info             Show GPU info
  snapshot         Generate debug snapshot
  list-profiles    List profiles
  current-profile  Current profile
  set-profile      Set profile
  help             Print this message or the help of the given subcommand(s)

Options:
  -g, --gpu-id <GPU_ID>  
  -h, --help             Print help
  -V, --version          Print version

# ===

Usage: lact cli set-profile --name <NAME> --auto-switch <AUTO_SWITCH>

Options:
  -n, --name <NAME>                
  -a, --auto-switch <AUTO_SWITCH>  [possible values: true, false]
  -h, --help                       Print help
```

**Tested with:**
- Fedora binaries
- Flatpak build

**Notes**
The `--auto-switch` argument is non-optional in the code but is optional via the socket. I think optional is better but it would require some further code changes.
https://github.com/ilya-zlobintsev/LACT/blob/e4d1f1d2669a8d2869ee7e61a491144985432220/lact-client/src/lib.rs#L154
