### PR TITLE
fix(flatpak): don't output startup success for flatpak cli

### DIFF
--- a/flatpak/startup.sh
+++ b/flatpak/startup.sh
@@ -75,10 +75,6 @@ WantedBy=multi-user.target\
     else
         echo "Service setup rejected, skipping"
     fi
-else
-    if [ "$1" != "cli" ]; then
-        echo "${DAEMON_SOCKET} exists, skipping setup prompt"
-    fi
 fi
 
 lact $@

--- a/flatpak/startup.sh
+++ b/flatpak/startup.sh
@@ -76,7 +76,9 @@ WantedBy=multi-user.target\
         echo "Service setup rejected, skipping"
     fi
 else
-    echo "${DAEMON_SOCKET} exists, skipping setup prompt"
+    if [ "$1" != "cli" ]; then
+        echo "${DAEMON_SOCKET} exists, skipping setup prompt"
+    fi
 fi
 
 lact $@


### PR DESCRIPTION
Missed this for Flatpak in #760

Using the cli with Flatpak outputs:
```sh
$ flatpak run io.github.ilya_zlobintsev.LACT cli profile set "Balanced"
/run/lactd.sock exists, skipping setup prompt
Balanced
```

Thanks