### PR TITLE
fix: fix excessive cubic spline interpolation density

### DIFF
--- a/lact-gui/src/app/graphs_window/plot/render_thread.rs
+++ b/lact-gui/src/app/graphs_window/plot/render_thread.rs
@@ -304,6 +304,7 @@ impl RenderRequest {
                             let segment_duration = (second_time - first_time) as f64;
                             let step = segment_duration / (POINTS_PER_SEGMENT as f64 - 1.0);
 
+                            // Evaluate spline at POINTS_PER_SEGMENT evenly spaced points per segment.
                             (0..POINTS_PER_SEGMENT).map(move |i| {
                                 let offset = (i as f64 * step).round() as i64;
                                 let current_date = first_time + offset;


### PR DESCRIPTION
- Replace 1ms high-frequency interpolation with fixed 4 points per spline segment
- Addresses excessive rendering density (500 points per 500ms data segment)
- Maintains visual quality while significantly improving performance
- Subjectively improves line smoothness in visual tests

## Problem
Excessive cubic spline interpolation density (1ms sampling) created ~500 points per 500ms segment, causing unnecessary rendering overhead with no visual benefit.

## Solution
Replace 1ms high-frequency interpolation with fixed 4 points per spline segment.

## Changes
- **File**: `lact-gui/src/app/graphs_window/plot/render_thread.rs`
- **Before**: `(first_time..second_time).map(...)` (1ms interval)
- **After**: Fixed 4 points per segment with `const POINTS_PER_SEGMENT: usize = 4`

## Performance Impact
- **Point reduction**: 99.2% fewer points (500 → 4 per 500ms segment)
- **Result**: Faster rendering, lower CPU usage

## Visual Quality
- **Testing**: No perceptible difference in curve smoothness
- **Subjective**: Improved visual clarity in tests

|    Before    |    After    |
| -------------- | -------------- |
| <img width="907" height="976" alt="截图 2025-12-17 00-23-18" src="https://github.com/user-attachments/assets/9f5f7391-83f6-4042-9b7d-5b45d05cc22b" /> | <img width="907" height="976" alt="截图 2025-12-17 00-24-11" src="https://github.com/user-attachments/assets/9096c3ed-fbf7-4a64-9bf6-0494461bd987" /> |

## Why 4 Points?
Cubic splines require 4 coefficients (a,b,c,d) → 4 points uniquely determine the curve. Additional points provide no mathematical benefit for rendering.

## Summary
Eliminates performance bottleneck while preserving visual quality. Optimizes chart rendering without compromising user experience.
