### PR TITLE
fix: replace broken icons

### DIFF
--- a/lact-gui/src/app/graphs_window/plot_component.rs
+++ b/lact-gui/src/app/graphs_window/plot_component.rs
@@ -81,7 +81,7 @@ impl relm4::factory::FactoryComponent for PlotComponent {
                         set_halign: gtk::Align::End,
                         set_valign: gtk::Align::Start,
                         set_margin_all: 20,
-                        set_icon_name: "info-symbolic",
+                        set_icon_name: "info-outline-symbolic",
                         set_tooltip: &fl!(I18N, "plot-show-detailed-info"),
                         set_opacity: 0.8,
                         bind: &self.print_extra_info,

--- a/lact-gui/src/app/header.rs
+++ b/lact-gui/src/app/header.rs
@@ -134,7 +134,7 @@ impl Component for Header {
                                     },
 
                                     gtk::Button {
-                                        set_icon_name: "document-import-symbolic",
+                                        set_icon_name: "folder-open-symbolic",
                                         set_tooltip: &fl!(I18N, "import-profile"),
                                         set_expand: true,
                                         connect_clicked => HeaderMsg::ImportProfile,


### PR DESCRIPTION
found 2 more broken icons.
before(flatpak):
<img width="399" height="215" alt="image" src="https://github.com/user-attachments/assets/9a80119c-a09d-498a-9f54-4f30153fdd8e" />
<img width="559" height="284" alt="image" src="https://github.com/user-attachments/assets/92a0ecfc-2a19-424a-81d4-79c0b907fef9" />
after:
<img width="359" height="217" alt="image" src="https://github.com/user-attachments/assets/320dd219-de0c-408d-a5c3-ca9a0db75051" />
<img width="580" height="262" alt="image" src="https://github.com/user-attachments/assets/dae9d335-c142-42b6-9a28-ea84353bc335" />
