### PR TITLE
fix: Start after systemd-udev

### DIFF
--- a/res/lactd.service
+++ b/res/lactd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=LACT GPU Control Daemon
-After=multi-user.target
+After=systemd-udev.service
 
 [Service]
 ExecStart=lact daemon


### PR DESCRIPTION
Having `After=multi-user.target` as well as `WantedBy=multi-user.target` isn't really a useful combination for a service since that means that systemd will wait for the rest of multi-user.target to be loaded before starting lactd.service and only once it finishes starting lactd.service will it continue with starting things that depend on multi-user.target. Doing that will increase time-to-login-manager by however long it takes lactd.service to start since the otherwise-parallel service startup will be blocked until that completes. Instead we can have it start after systemd-udev by which point the kernel modules should already be loaded.