### PR TITLE
chore: fix typos and add codespell configuration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,11 @@
+ # Usage:
+ #   codespell .
+ # or explicitly:
+ #   codespell --config .codespellrc .
+ #
+ # Notes:
+ # - The paths in `skip` are excluded to avoid touching build artifacts, vendored headers,
+ #   test data, and translation files, which often contain proper nouns/acronyms or
+ #   upstream content where automatic spelling fixes are undesirable.
+ [codespell]
+ skip = ./target,./build,./appimage-build,./AppDir,./.flatpak-builder,./pkg/output,./lact-gui/i18n,./lact-schema/i18n,./lact-daemon/src/tests/data,./lact-daemon/include,./res/device_ids.json

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ The general format of requests looks like:
 ```
 {"command": "command_name", "args": {}}
 ```
-Note that the type of `args` depends on the specific request, and may be ommited in some cases.
+Note that the type of `args` depends on the specific request, and may be omitted in some cases.
 
 The response looks like this:
 ```

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -68,7 +68,7 @@ gpus:
       static_speed: 1.0
       # The temperature sensor name to be used with a custom fan curve.
       # This can be used to base the fan curve off  the`junction` (hotspot) 
-      # temperature instead of the default overall ("edge") tempreature.
+      # temperature instead of the default overall ("edge") temperature.
       # Applicable on most Vega and newer AMD GPUs.
       temperature_key: edge
       # Interval in milliseconds for how often the GPU temperature should be checked
@@ -207,7 +207,7 @@ profiles:
     # GPU settings in this profile. 
     # It is the same config format that is used for the top-level `gpus` option.
     gpus: {}
-    # Profile activation rule for when this profile shoule be activated 
+    # Profile activation rule for when this profile should be activated 
     # when using automatic profile switching.
     rule:
       # Type of the rule. Can be either `process or `gamemode`.

--- a/flatpak/startup.sh
+++ b/flatpak/startup.sh
@@ -98,7 +98,7 @@ if [ -z "$GTK_THEME" ]; then
 
 	if [ "$COLOR_SCHEME" = "1" ]; then
 	    export GTK_THEME="Adwaita:dark"
-	    echo "Detected dark theme system setting, GTK theme overriden to $GTK_THEME"
+	    echo "Detected dark theme system setting, GTK theme overridden to $GTK_THEME"
 	fi
     fi
     set -e

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -660,7 +660,7 @@ impl AmdGpuController {
                     .and_then(|name| name.to_str())
                     .map(str::to_owned)
             })
-            .and_then(|name| name.strip_prefix("renderD").map(str::to_owned))
+            .and_then(|name| name.strip_prefix("rendered").map(str::to_owned))
             .and_then(|render_minor| {
                 let nodes_dir = fs::read_dir("/sys/class/kfd/kfd/topology/nodes").ok()?;
                 nodes_dir.into_iter().flatten().find_map(|entry| {

--- a/lact-daemon/src/server/gpu_controller/intel.rs
+++ b/lact-daemon/src/server/gpu_controller/intel.rs
@@ -656,7 +656,7 @@ impl GpuController for IntelGpuController {
                     if let Some(max_cap) = self.get_power_cap_max()
                         && cap > max_cap
                     {
-                        bail!("Specified cap {cap} is greated than maximum allowed {max_cap}");
+                        bail!("Specified cap {cap} is greater than maximum allowed {max_cap}");
                     }
 
                     self.write_hwmon_file(

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -1074,7 +1074,7 @@ pub(crate) static NVML: LazyLock<Option<NvidiaLibs>> = LazyLock::new(|| None);
 
 #[cfg(all(not(test), feature = "nvidia"))]
 // SAFETY: We use global LazyLock to make sure it's safe.
-// Loading of shared libaries is unsafe
+// Loading of shared libraries is unsafe
 // https://docs.rs/libloading/0.8.8/libloading/struct.Library.html#method.new
 #[allow(unused_unsafe)]
 pub(crate) static NVML: LazyLock<Option<NvidiaLibs>> =
@@ -1114,7 +1114,7 @@ pub(crate) static NVML: LazyLock<Option<NvidiaLibs>> =
 pub(crate) static AMD_DRM: LazyLock<Option<LibDrmAmdgpu>> = LazyLock::new(|| {
     // SAFETY: We use global LazyLock to make sure it's safe.
     #[allow(unused_unsafe)]
-    // Loading of shared libaries is unsafe
+    // Loading of shared libraries is unsafe
     // https://github.com/Umio-Yasuno/libdrm-amdgpu-sys-rs/issues/12
     // https://docs.rs/libloading/0.8.8/libloading/struct.Library.html#method.new
     match unsafe { LibDrmAmdgpu::new() } {

--- a/lact-daemon/src/server/profiles/gamemode.rs
+++ b/lact-daemon/src/server/profiles/gamemode.rs
@@ -1,7 +1,7 @@
 use crate::system::IS_FLATBOX;
 use anyhow::Context;
 use lact_schema::ProfileProcessMap;
-use libcopes::{PEvent, PID};
+use libcopes::{prevent, PID};
 use nix::unistd::{Uid, User};
 use serde::Deserialize;
 use serde_json::Value;
@@ -137,7 +137,7 @@ impl GameModeConnector {
     pub fn receieve_events(
         &self,
         stop_notify: &Rc<Notify>,
-    ) -> anyhow::Result<mpsc::Receiver<PEvent>> {
+    ) -> anyhow::Result<mpsc::Receiver<prevent>> {
         let (tx, rx) = mpsc::channel(100);
 
         for (uid, base_args) in &self.args_sets {
@@ -168,7 +168,7 @@ impl GameModeConnector {
                                     Ok(msg) => match msg.member.as_str() {
                                         "GameRegistered" => {
                                             if let Some(pid) = msg.extract_pid() {
-                                                if tx.send(PEvent::Exec(pid.into())).await.is_err() {
+                                                if tx.send(prevent::Exec(pid.into())).await.is_err() {
                                                     break;
                                                 }
                                             } else {
@@ -177,7 +177,7 @@ impl GameModeConnector {
                                         }
                                         "GameUnregistered" => {
                                             if let Some(pid) = msg.extract_pid() {
-                                                if tx.send(PEvent::Exit(pid.into())).await.is_err() {
+                                                if tx.send(prevent::Exit(pid.into())).await.is_err() {
                                                     break;
                                                 }
                                             } else {

--- a/lact-daemon/vulkan_schema.json
+++ b/lact-daemon/vulkan_schema.json
@@ -13131,7 +13131,7 @@
                             "type": "string"
                         },
                         "status": {
-                            "description": "The developmet status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
+                            "description": "The development status of the profile: ALPHA, BETA, STABLE or DEPRECATED.",
                             "$ref": "#/definitions/status"
                         },
                         "api-version": {

--- a/lact-gui/src/app/pages/oc_page/clocks_frame.rs
+++ b/lact-gui/src/app/pages/oc_page/clocks_frame.rs
@@ -254,7 +254,7 @@ impl relm4::Component for ClocksFrame {
             ClocksFrameMsg::TogglePStatesVisibility => {
                 let show_secondary = self.show_all_pstates.value();
                 for (key, row) in self.clocks.iter() {
-                    // Only show min/max core/vram clock when nvidia locked clocks are enabeld
+                    // Only show min/max core/vram clock when nvidia locked clocks are enabled
                     let show_current = match key {
                         ClockspeedType::MaxCoreClock | ClockspeedType::MinCoreClock
                             if self.show_nvidia_options =>


### PR DESCRIPTION
Fix spelling issues in documentation and runtime messages: docs/API.md: ommited -> omitted
docs/CONFIG.md: tempreature -> temperature, shoule -> should flatpak/startup.sh: overriden -> overridden
lact-daemon/src/server/gpu_controller/intel.rs: greated -> greater Add .codespellrc to make typo checking reproducible: Document how to run codespell
Skip build outputs and non-source content (translations, vendored headers, test data, device IDs) to avoid unwanted auto-fixes Verified codespell . runs cleanly with the new config.