### PR TITLE
fix: tolerate unsuccessful clock offset reset on nvidia

### DIFF
--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -921,11 +921,9 @@ impl GpuController for NvidiaGpuController {
                                 .is_some_and(|offset| *offset != 0))
                     {
                         debug!("resetting clock offset for {clock_type:?} pstate {pstate:?}");
-                        device
-                            .set_clock_offset(clock_type, pstate, 0)
-                            .with_context(|| {
-                                format!("Could not reset {clock_type:?} pstate {pstate:?}")
-                            })?;
+                        if let Err(err) = device.set_clock_offset(clock_type, pstate, 0) {
+                            warn!("could not reset {clock_type:?} pstate {pstate:?}: {err:#}");
+                        }
                     }
 
                     if let Some(applied_offsets) =


### PR DESCRIPTION
addresses #664

so it seems another instance where nvmlDeviceSetClockOffsets doesn't understand pStates.

in the config we have 
```
gpu_clock_offsets: {
  0: -100,
},
```
but in the info.json we see
```
"gpu_offsets": {
  "0": {
    "current": -100,
    "max": 1000,
    "min": -1000
  },
  "2": {
    "current": -100,
    "max": 1000,
    "min": -1000
  },
  "5": {
    "current": 0,
    "max": 1000,
    "min": -1000
  },
  "8": {
    "current": 0,
    "max": 0,
    "min": 0
  }
},
```
evidently p0 and p2 are linked for Maxwell.

On amd we tolerate if reset clocks fails:
lact-daemon/src/server/gpu_controller/amd.rs:1065
```rust
self.handle.reset_clocks_table().ok();
```

I suggest to do the same here. Alternatively we can do something like - fail if we managed to reset none of clocks.