### PR TITLE
feat: restrict content max width

### DIFF
--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -133,13 +133,14 @@ impl AsyncComponent for AppModel {
                 gtk::Box {
                     set_orientation: gtk::Orientation::Vertical,
 
-                    gtk::ScrolledWindow {
+                    adw::Clamp {
+                        set_maximum_size: CONTENT_MAXIMUM_WIDTH,
+                        set_hexpand: true,
                         set_vexpand: true,
-                        set_hscrollbar_policy: gtk::PolicyType::Never,
 
-                        adw::ClampScrollable {
-                            set_maximum_size: CONTENT_MAXIMUM_WIDTH,
-                            set_hexpand: true,
+                        gtk::ScrolledWindow {
+                            set_vexpand: true,
+                            set_hscrollbar_policy: gtk::PolicyType::Never,
 
                             #[name = "root_stack"]
                             gtk::Stack {

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -86,6 +86,8 @@ static ERROR_WINDOW_COUNT: AtomicU32 = AtomicU32::new(0);
 const PROCESS_POLL_INTERVAL_MS: u64 = 1500;
 const NVIDIA_RECOMMENDED_MIN_VERSION: u32 = 560;
 
+const CONTENT_MAXIMUM_WIDTH: i32 = 1200;
+
 pub struct AppModel {
     daemon_client: DaemonClient,
     graphs_window: relm4::Controller<GraphsWindow>,
@@ -136,29 +138,34 @@ impl AsyncComponent for AppModel {
                         set_vexpand: true,
                         set_hscrollbar_policy: gtk::PolicyType::Never,
 
-                        #[name = "root_stack"]
-                        gtk::Stack {
-                            set_vexpand: false,
-                            set_vhomogeneous: false,
+                        adw::ClampScrollable {
+                            set_maximum_size: CONTENT_MAXIMUM_WIDTH,
+                            set_hexpand: true,
 
-                            add_binding: (&model.ui_sensitive, "sensitive"),
+                            #[name = "root_stack"]
+                            gtk::Stack {
+                                set_vexpand: false,
+                                set_vhomogeneous: false,
 
-                            add_titled[Some("info_page"), &fl!(I18N, "info-page")] = model.info_page.widget(),
-                            add_titled[Some("oc_page"), &fl!(I18N, "oc-page")] = model.oc_page.widget(),
-                            add_titled[Some("thermals_page"), &fl!(I18N, "thermals-page")] = model.thermals_page.widget(),
-                            add_titled[Some("software_page"), &fl!(I18N, "software-page")] = model.software_page.widget(),
-                            add_named[Some("crash_page")] = model.crash_page.widget(),
+                                add_binding: (&model.ui_sensitive, "sensitive"),
 
-                            set_visible_child_name: &CONFIG.read().selected_tab,
-                            connect_visible_child_name_notify => move |stack| {
-                                if let Some(name) = stack.visible_child_name() {
-                                    let name = name.to_string();
-                                    if name != "crash_page" {
-                                        CONFIG.write().edit(|config| {
-                                            config.selected_tab = name;
-                                        });
+                                add_titled[Some("info_page"), &fl!(I18N, "info-page")] = model.info_page.widget(),
+                                add_titled[Some("oc_page"), &fl!(I18N, "oc-page")] = model.oc_page.widget(),
+                                add_titled[Some("thermals_page"), &fl!(I18N, "thermals-page")] = model.thermals_page.widget(),
+                                add_titled[Some("software_page"), &fl!(I18N, "software-page")] = model.software_page.widget(),
+                                add_named[Some("crash_page")] = model.crash_page.widget(),
+
+                                set_visible_child_name: &CONFIG.read().selected_tab,
+                                connect_visible_child_name_notify => move |stack| {
+                                    if let Some(name) = stack.visible_child_name() {
+                                        let name = name.to_string();
+                                        if name != "crash_page" {
+                                            CONFIG.write().edit(|config| {
+                                                config.selected_tab = name;
+                                            });
+                                        }
                                     }
-                                }
+                                },
                             },
                         },
                     },

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -85,7 +85,6 @@ static ERROR_WINDOW_COUNT: AtomicU32 = AtomicU32::new(0);
 
 const PROCESS_POLL_INTERVAL_MS: u64 = 1500;
 const NVIDIA_RECOMMENDED_MIN_VERSION: u32 = 560;
-
 const CONTENT_MAXIMUM_WIDTH: i32 = 1200;
 
 pub struct AppModel {

--- a/lact-gui/src/app/info_row_level.rs
+++ b/lact-gui/src/app/info_row_level.rs
@@ -100,7 +100,8 @@ mod imp {
                 }
             ));
             let spring_params = adw::SpringParams::new(1.0, 1.0, 800.0);
-            let animation = adw::SpringAnimation::new(&level_bar, 0.0, 0.0, spring_params, animation_target);
+            let animation =
+                adw::SpringAnimation::new(&level_bar, 0.0, 0.0, spring_params, animation_target);
             animation.set_clamp(true);
             self.animation.replace(Some(animation));
         }

--- a/lact-gui/src/app/pages/oc_page/clocks_frame/adjustment_row.rs
+++ b/lact-gui/src/app/pages/oc_page/clocks_frame/adjustment_row.rs
@@ -106,7 +106,7 @@ impl FactoryComponent for ClockAdjustmentRow {
                     set_digits: 0,
                     set_round_digits: 0,
                     set_value_pos: gtk::PositionType::Right,
-                    set_width_request: 150,
+                    set_width_request: 130,
                     add_controller = make_event_controller_no_scroll(),
                 },
 


### PR DESCRIPTION
<img width="2560" height="1406" alt="image" src="https://github.com/user-attachments/assets/67a257e4-6227-4f27-8849-a5b7a21d7ca3" />
<img width="2560" height="1406" alt="image" src="https://github.com/user-attachments/assets/a5535ff6-16cf-4745-8afe-2d9aeed68f50" />
<img width="2560" height="1406" alt="image" src="https://github.com/user-attachments/assets/cb0ee969-0a8e-4b27-ba8c-dac48eef2bc3" />
<img width="2560" height="1406" alt="image" src="https://github.com/user-attachments/assets/f077a426-82c0-48f8-bb20-b5103bbd65e8" />
<img width="2560" height="1406" alt="image" src="https://github.com/user-attachments/assets/5ea1be24-c033-426b-8a19-c821038d16f4" />
curve is big enough, I don't making it bigger improves usability

I specifically decided not to touch header and applyRevealer because it will be moved to the sidebar short term