### PR TITLE
Add phoenix to manual preformance level quirks

### DIFF
--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -673,7 +673,8 @@ impl AmdGpuController {
 
     fn apply_clocks_config_require_manual_proformance_level(&self) -> bool {
         self.common.pci_info.device_pci_info.vendor_id == VENDOR_AMD
-            && REQUIRE_MANUAL_DEVICE_IDS.contains(&self.common.pci_info.device_pci_info.model_id.as_str())
+            && REQUIRE_MANUAL_DEVICE_IDS
+                .contains(&self.common.pci_info.device_pci_info.model_id.as_str())
     }
 
     #[cfg(not(test))]


### PR DESCRIPTION
Tested on
```
63:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Phoenix1 (rev c2) (prog-if 00 [VGA controller])
        Subsystem: AIstone Global Limited Device 140b
        Flags: bus master, fast devsel, latency 0, IRQ 47, IOMMU group 16
        Memory at 7c00000000 (64-bit, prefetchable) [size=256M]
        Memory at 78000000 (64-bit, prefetchable) [size=2M]
        I/O ports at 1000 [size=256]
        Memory at 78500000 (32-bit, non-prefetchable) [size=512K]
        Capabilities: <access denied>
        Kernel driver in use: amdgpu
        Kernel modules: amdgpu
```