### PR TITLE
feat: add Nvidia VF curve editor

### DIFF
--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -5,7 +5,11 @@ use super::{CommonControllerInfo, FanControlHandle, GpuController};
 use crate::{
     bindings::nvidia::NvPhysicalGpuHandle,
     server::{
-        gpu_controller::{NvApi, common::fan_control::FanCurveExt, common::resolve_process_name},
+        gpu_controller::{
+            NvApi,
+            common::{fan_control::FanCurveExt, resolve_process_name},
+            nvidia::nvapi::{CLOCK_CLIENT_CLK_VF_POINT_TYPE_PROG, ClockClientClkVfPointInfoV1},
+        },
         opencl::get_opencl_info,
         vulkan::get_vulkan_info,
     },
@@ -21,10 +25,10 @@ use indexmap::IndexMap;
 use lact_schema::{
     CacheInfo, ClocksInfo, ClocksTable, ClockspeedStats, DeviceFlag, DeviceInfo, DeviceStats,
     DeviceType, DrmInfo, DrmMemoryInfo, FanControlMode, FanStats, IntelDrmInfo, LinkInfo,
-    NvidiaClockOffset, NvidiaClocksTable, PmfwInfo, PowerState, PowerStates, PowerStats,
-    ProcessInfo, ProcessList, ProcessType, ProcessUtilizationType, TemperatureEntry, VoltageStats,
-    VramStats,
-    config::{FanControlSettings, FanCurve, GpuConfig},
+    NvidiaClockOffset, NvidiaClocksTable, NvidiaVfPoint, PmfwInfo, PowerState, PowerStates,
+    PowerStats, ProcessInfo, ProcessList, ProcessType, ProcessUtilizationType, TemperatureEntry,
+    VoltageStats, VramStats,
+    config::{CurvePoint, FanControlSettings, FanCurve, GpuConfig},
 };
 use nvml_wrapper::{
     Device, Nvml,
@@ -53,13 +57,12 @@ const SUPPORTED_UTIL_TYPES: &[ProcessUtilizationType] = &[
 
 pub struct NvidiaGpuController {
     nvml: &'static Nvml,
-    nvapi: Option<&'static NvApi>,
     common: CommonControllerInfo,
     fan_control_handle: RefCell<Option<FanControlHandle>>,
     initial_target_temp: Option<u32>,
 
+    nvapi: Option<(&'static NvApi, NvPhysicalGpuHandle)>,
     driver_handle: Option<DriverHandle>,
-    nvapi_handle: Option<NvPhysicalGpuHandle>,
     nvapi_thermals_mask: Option<i32>,
 
     last_util_timestamp: Cell<Option<u64>>,
@@ -67,6 +70,8 @@ pub struct NvidiaGpuController {
     last_applied_offsets: RefCell<HashMap<Clock, HashMap<PerformanceState, i32>>>,
     last_applied_gpu_locked_clocks: RefCell<Option<(u32, u32)>>,
     last_applied_vram_locked_clocks: RefCell<Option<(u32, u32)>>,
+    // Check if reset is needed to avoid unnecessarily going to nvapi
+    vf_curve_written: Cell<bool>,
 }
 
 impl NvidiaGpuController {
@@ -130,10 +135,9 @@ impl NvidiaGpuController {
 
         Ok(Self {
             nvml,
-            nvapi,
+            nvapi: nvapi.zip(nvapi_handle),
             common,
             driver_handle,
-            nvapi_handle,
             nvapi_thermals_mask,
             initial_target_temp: target_temp,
             last_util_timestamp: Cell::new(None),
@@ -141,6 +145,7 @@ impl NvidiaGpuController {
             last_applied_offsets: RefCell::new(HashMap::new()),
             last_applied_gpu_locked_clocks: RefCell::new(None),
             last_applied_vram_locked_clocks: RefCell::new(None),
+            vf_curve_written: Cell::new(false),
         })
     }
 
@@ -376,6 +381,141 @@ impl NvidiaGpuController {
 
         Ok(power_states)
     }
+
+    fn get_vf_curve(&self) -> anyhow::Result<Vec<NvidiaVfPoint>> {
+        if let Some((nvapi, handle)) = self.nvapi.as_ref() {
+            let info;
+            let status;
+
+            unsafe {
+                info = nvapi.clock_client_clk_vf_points_get_info(*handle)?;
+                status =
+                    nvapi.clock_client_clk_vf_points_get_status(*handle, info.vf_points_mask)?;
+            }
+
+            let point_count = point_count_from_mask(info.vf_points_mask);
+            let mut curve = Vec::with_capacity(point_count);
+
+            for i in 0..point_count {
+                let point = status.vf_points[i];
+                let point_info = info.vf_points[i];
+
+                // Only report configurable and voltage-based points
+                if !vf_curve_point_is_editable(point_info) {
+                    continue;
+                }
+
+                curve.push(NvidiaVfPoint {
+                    index: u8::try_from(i).expect("max 255 points"),
+                    freq: point.freq_khz / 1000,
+                    voltage: point.voltage_uv / 1000,
+                    base_freq: point.vf_tuple_base.freq_khz / 1000,
+                    base_voltage: point.vf_tuple_base.voltage_uv / 1000,
+                });
+            }
+
+            Ok(curve)
+        } else {
+            Err(anyhow!("NvAPI not available"))
+        }
+    }
+
+    #[expect(clippy::similar_names)]
+    fn apply_vf_curve(&self, curve: &IndexMap<u8, CurvePoint>) -> anyhow::Result<()> {
+        let (nvapi, handle) = self.nvapi.as_ref().context("NvAPI not available")?;
+
+        debug!("applying curve with {} points", curve.len());
+
+        let info = unsafe { nvapi.clock_client_clk_vf_points_get_info(*handle)? };
+        let current_vf_curve =
+            unsafe { nvapi.clock_client_clk_vf_points_get_status(*handle, info.vf_points_mask)? };
+        let mut curve_control =
+            unsafe { nvapi.clock_client_clk_vf_get_control(*handle, info.vf_points_mask)? };
+
+        let offset_info = self
+            .device()
+            .clock_offset(Clock::Graphics, PerformanceState::Zero)
+            .context("Could not get offset info")?;
+
+        for (i, configured_point) in curve {
+            let i = *i as usize;
+
+            let point_info = info.vf_points[i];
+            let current_point = current_vf_curve.vf_points[i];
+            let point_control = &mut curve_control.vf_points[i];
+
+            if !vf_curve_point_is_editable(point_info) {
+                bail!("Trying to edit non-configurable point {i}");
+            }
+
+            if let Some(configured_mv) = configured_point.voltage {
+                let current_mv = (current_point.voltage_uv / 1000).cast_signed();
+                if configured_mv != current_mv {
+                    bail!(
+                        "Voltage is immutable - point {i} was attempted to be changed from {current_mv}mV to {configured_mv}mV"
+                    );
+                }
+            }
+
+            if let Some(configured_mhz) = configured_point.clockspeed {
+                let offset_khz =
+                    configured_mhz * 1000 - current_point.vf_tuple_base.freq_khz.cast_signed();
+                let offset_mhz = offset_khz / 1000;
+
+                let min_offset = cmp::min(
+                    offset_info.min_clock_offset_mhz,
+                    -((current_point.vf_tuple_base.freq_khz / 1000).cast_signed()),
+                );
+
+                if !(min_offset..=offset_info.max_clock_offset_mhz).contains(&offset_mhz) {
+                    bail!("Configured offset {offset_mhz}MHz is outside of the allowed range",);
+                }
+
+                debug!("writing offset {offset_khz}KHz to point {i}");
+
+                point_control.data.prog.freq_offset_khz = offset_khz;
+            }
+        }
+
+        unsafe {
+            nvapi.clock_client_clk_vf_set_control(*handle, curve_control)?;
+        }
+
+        self.vf_curve_written.set(true);
+
+        Ok(())
+    }
+
+    fn reset_vf_curve(&self) -> anyhow::Result<()> {
+        let (nvapi, handle) = self.nvapi.as_ref().context("NvAPI not available")?;
+
+        let info = unsafe { nvapi.clock_client_clk_vf_points_get_info(*handle)? };
+        let mut curve_control =
+            unsafe { nvapi.clock_client_clk_vf_get_control(*handle, info.vf_points_mask)? };
+
+        for i in 0..point_count_from_mask(info.vf_points_mask) {
+            let point_info = info.vf_points[i];
+            if vf_curve_point_is_editable(point_info) {
+                curve_control.vf_points[i].data.prog.freq_offset_khz = 0;
+            }
+        }
+
+        unsafe {
+            nvapi.clock_client_clk_vf_set_control(*handle, curve_control)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn vf_curve_point_is_editable(point: ClockClientClkVfPointInfoV1) -> bool {
+    point.b_voltage_based == 1 && point.type_ == CLOCK_CLIENT_CLK_VF_POINT_TYPE_PROG
+}
+
+fn point_count_from_mask(mask: [u32; 8]) -> usize {
+    let count: usize = mask.iter().map(|i| i.count_ones() as usize).sum();
+    assert!(u8::try_from(count).is_ok());
+    count
 }
 
 impl GpuController for NvidiaGpuController {
@@ -529,7 +669,7 @@ impl GpuController for NvidiaGpuController {
 
         let mut voltage = None;
 
-        if let (Some(nvapi), Some(handle)) = (self.nvapi.as_ref(), self.nvapi_handle.as_ref()) {
+        if let Some((nvapi, handle)) = self.nvapi.as_ref() {
             unsafe {
                 if let Some(mask) = self.nvapi_thermals_mask
                     && let Ok(thermals) = nvapi.get_thermals(*handle, mask)
@@ -753,6 +893,11 @@ impl GpuController for NvidiaGpuController {
             }
         }
 
+        let gpu_vf_curve = self
+            .get_vf_curve()
+            .inspect_err(|err| warn!("could not get VF curve: {err:#}"))
+            .unwrap_or_default();
+
         let table = NvidiaClocksTable {
             gpu_offsets,
             mem_offsets,
@@ -760,6 +905,7 @@ impl GpuController for NvidiaGpuController {
             vram_locked_clocks: *self.last_applied_vram_locked_clocks.borrow(),
             gpu_clock_range,
             vram_clock_range,
+            gpu_vf_curve,
         };
 
         Ok(ClocksInfo {
@@ -900,6 +1046,11 @@ impl GpuController for NvidiaGpuController {
                     .insert(pstate, *offset);
             }
 
+            if !clocks.gpu_vf_curve.is_empty() {
+                self.apply_vf_curve(&clocks.gpu_vf_curve)
+                    .context("Could not apply VF curve")?;
+            }
+
             if config.fan_control_enabled {
                 let settings = config
                     .fan_control_settings
@@ -1010,6 +1161,10 @@ impl GpuController for NvidiaGpuController {
                 .reset_mem_locked_clocks()
                 .context("Could not reset locked GPU clocks")?;
             self.last_applied_vram_locked_clocks.take();
+        }
+
+        if self.vf_curve_written.get() {
+            self.reset_vf_curve().context("Could not reset VF curve")?;
         }
 
         Ok(())

--- a/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
@@ -1,7 +1,13 @@
 #![cfg_attr(test, allow(unused))]
-#![allow(clippy::unreadable_literal, unsafe_op_in_unsafe_fn)]
+#![allow(
+    clippy::unreadable_literal,
+    unsafe_op_in_unsafe_fn,
+    clippy::large_stack_arrays
+)]
+
 use crate::bindings::nvidia::{
-    NVAPI_MAX_PHYSICAL_GPUS, NVAPI_SHORT_STRING_MAX, NvAPI_Status, NvPhysicalGpuHandle,
+    NVAPI_MAX_PHYSICAL_GPUS, NVAPI_SHORT_STRING_MAX, NvAPI_Status, NvPhysicalGpuHandle, NvS32,
+    NvU8, NvU32,
 };
 use anyhow::{Context, bail};
 use std::{
@@ -18,8 +24,15 @@ const QUERY_NVAPI_UNLOAD: u32 = 0xd22bdd7e;
 const QUERY_NVAPI_ENUM_PHYSICAL_GPUS: u32 = 0xe5ac921f;
 const QUERY_NVAPI_GET_BUS_ID: u32 = 0x1be0b8e5;
 const QUERY_NVAPI_GET_ERROR_MESSAGE: u32 = 0x6c2d048c;
-const QUERY_NVAPI_THERMALS: u32 = 0x65fe3aad; // Undocumented call
-const QUERY_NVAPI_VOLTAGE: u32 = 0x465f9bcf; // Undocumented call
+// Undocumented calls
+const QUERY_NVAPI_THERMALS: u32 = 0x65fe3aad;
+const QUERY_NVAPI_VOLTAGE: u32 = 0x465f9bcf;
+const QUERY_NVAPI_GPU_CLOCK_CLIENT_CLK_VF_POINTS_GET_STATUS: u32 = 0x21537ad4;
+const QUERY_NVAPI_GPU_CLOCK_CLIENT_CLK_VF_POINTS_GET_INFO: u32 = 0x507b4b59;
+const QUERY_NVAPI_GPU_CLOCK_CLIENT_CLK_VF_POINTS_SET_CONTROL: u32 = 0x733e009;
+const QUERY_NVAPI_GPU_CLOCK_CLIENT_CLK_VF_POINTS_GET_CONTROL: u32 = 0x23f1b133;
+
+pub const CLOCK_CLIENT_CLK_VF_POINT_TYPE_PROG: NvU32 = 0;
 
 pub struct NvApi {
     lib: libloading::Library,
@@ -81,7 +94,7 @@ impl NvApi {
 
         let mut sensors = NvApiThermals {
             #[allow(clippy::cast_possible_truncation)]
-            version: (mem::size_of::<NvApiThermals>() | (2 << 16)) as u32,
+            version: make_version::<NvApiThermals>(2),
             mask,
             values: [0; 40],
         };
@@ -93,24 +106,85 @@ impl NvApi {
     }
 
     pub unsafe fn get_voltage(&self, handle: NvPhysicalGpuHandle) -> anyhow::Result<u32> {
-        let f = self.query_interface(QUERY_NVAPI_VOLTAGE)?;
-        let f: unsafe extern "C" fn(
-            handle: NvPhysicalGpuHandle,
-            data: &mut NvApiVoltage,
-        ) -> NvAPI_Status = transmute(f);
-
         let mut data = NvApiVoltage {
             #[allow(clippy::cast_possible_truncation)]
-            version: (mem::size_of::<NvApiVoltage>() | (1 << 16)) as u32,
+            version: make_version::<NvApiVoltage>(1),
             flags: 0,
             padding_1: [0; 8],
             value_uv: 0,
             padding_2: [0; 8],
         };
-        let status = f(handle, &mut data);
-        self.handle_status(status)?;
+
+        self.physical_gpu_query(handle, &mut data, QUERY_NVAPI_VOLTAGE)?;
 
         Ok(data.value_uv)
+    }
+
+    pub unsafe fn clock_client_clk_vf_points_get_info(
+        &self,
+        handle: NvPhysicalGpuHandle,
+    ) -> anyhow::Result<ClockClientClkVfPointsInfoV1> {
+        let mut data = ClockClientClkVfPointsInfoV1::default();
+
+        self.physical_gpu_query(
+            handle,
+            &mut data,
+            QUERY_NVAPI_GPU_CLOCK_CLIENT_CLK_VF_POINTS_GET_INFO,
+        )?;
+
+        Ok(data)
+    }
+
+    pub unsafe fn clock_client_clk_vf_points_get_status(
+        &self,
+        handle: NvPhysicalGpuHandle,
+        vf_points_mask: [NvU32; 8],
+    ) -> anyhow::Result<ClockClientClkVfPointsStatusV3> {
+        let mut data = ClockClientClkVfPointsStatusV3 {
+            vf_points_mask,
+            ..Default::default()
+        };
+
+        self.physical_gpu_query(
+            handle,
+            &mut data,
+            QUERY_NVAPI_GPU_CLOCK_CLIENT_CLK_VF_POINTS_GET_STATUS,
+        )?;
+
+        Ok(data)
+    }
+
+    pub unsafe fn clock_client_clk_vf_get_control(
+        &self,
+        handle: NvPhysicalGpuHandle,
+        vf_points_mask: [NvU32; 8],
+    ) -> anyhow::Result<ClockClientClkVfPointsControlV1> {
+        let mut data = ClockClientClkVfPointsControlV1 {
+            vf_points_mask,
+            ..Default::default()
+        };
+
+        self.physical_gpu_query(
+            handle,
+            &mut data,
+            QUERY_NVAPI_GPU_CLOCK_CLIENT_CLK_VF_POINTS_GET_CONTROL,
+        )?;
+
+        Ok(data)
+    }
+
+    pub unsafe fn clock_client_clk_vf_set_control(
+        &self,
+        handle: NvPhysicalGpuHandle,
+        mut control: ClockClientClkVfPointsControlV1,
+    ) -> anyhow::Result<()> {
+        self.physical_gpu_query(
+            handle,
+            &mut control,
+            QUERY_NVAPI_GPU_CLOCK_CLIENT_CLK_VF_POINTS_SET_CONTROL,
+        )?;
+
+        Ok(())
     }
 
     pub unsafe fn calculate_thermals_mask(
@@ -201,6 +275,21 @@ impl NvApi {
             );
         }
     }
+
+    unsafe fn physical_gpu_query<T>(
+        &self,
+        handle: NvPhysicalGpuHandle,
+        data: &mut T,
+        query_id: u32,
+    ) -> anyhow::Result<()> {
+        let f = self.query_interface(query_id)?;
+        let f: unsafe extern "C" fn(NvPhysicalGpuHandle, *mut T) -> NvAPI_Status = transmute(f);
+
+        let status = f(handle, data);
+        self.handle_status(status)?;
+
+        Ok(())
+    }
 }
 
 impl Drop for NvApi {
@@ -246,4 +335,138 @@ struct NvApiVoltage {
     padding_1: [u32; 8],
     value_uv: u32,
     padding_2: [u32; 8],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ClockClientClkVfPointsStatusV3 {
+    pub version: NvU32,
+    pub vf_points_mask: [NvU32; 8],
+    pub b_vf_tuple_base_supported: NvU8,
+    pub rsvd: [NvU8; 64],
+    pub vf_points: [ClockClientClkVfPointStatusV3; 255],
+}
+
+impl Default for ClockClientClkVfPointsStatusV3 {
+    fn default() -> Self {
+        Self {
+            version: make_version::<Self>(3),
+            vf_points_mask: [0; 8],
+            b_vf_tuple_base_supported: 0,
+            rsvd: [0; 64],
+            vf_points: [ClockClientClkVfPointStatusV3::default(); 255],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct ClockClientClkVfPointStatusV3 {
+    pub type_: NvU32,
+    pub freq_khz: NvU32,
+    pub voltage_uv: NvU32,
+    pub vf_tuple_base: ClockClientClkVfPointTupleV1,
+    pub vf_tuple_offset: ClockClientClkVfPointTupleV1,
+    pub rsvd: [NvU8; 256],
+}
+
+impl Default for ClockClientClkVfPointStatusV3 {
+    fn default() -> Self {
+        Self {
+            type_: Default::default(),
+            freq_khz: Default::default(),
+            voltage_uv: Default::default(),
+            vf_tuple_base: ClockClientClkVfPointTupleV1::default(),
+            vf_tuple_offset: ClockClientClkVfPointTupleV1::default(),
+            rsvd: [0; 256],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub struct ClockClientClkVfPointTupleV1 {
+    pub freq_khz: NvU32,
+    pub voltage_uv: NvU32,
+    pub rsvd: [NvU8; 32usize],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct ClockClientClkVfPointsInfoV1 {
+    pub version: NvU32,
+    pub vf_points_mask: [NvU32; 8],
+    pub rsvd: [NvU8; 32],
+    pub vf_points: [ClockClientClkVfPointInfoV1; 255],
+}
+
+impl Default for ClockClientClkVfPointsInfoV1 {
+    fn default() -> Self {
+        Self {
+            version: make_version::<Self>(1),
+            vf_points_mask: Default::default(),
+            rsvd: Default::default(),
+            vf_points: [ClockClientClkVfPointInfoV1::default(); 255],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub struct ClockClientClkVfPointInfoV1 {
+    pub type_: NvU32,
+    pub b_voltage_based: NvU8,
+    pub rsvd: [NvU8; 16],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ClockClientClkVfPointsControlV1 {
+    pub version: NvU32,
+    pub vf_points_mask: [NvU32; 8],
+    pub rsvd: [NvU8; 32usize],
+    pub vf_points: [ClockClientClkVfPointControlV1; 255usize],
+}
+
+impl Default for ClockClientClkVfPointsControlV1 {
+    fn default() -> Self {
+        Self {
+            version: make_version::<Self>(1),
+            vf_points_mask: [0; 8],
+            rsvd: [0; 32],
+            vf_points: [ClockClientClkVfPointControlV1::default(); 255],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct ClockClientClkVfPointControlV1 {
+    pub type_: NvU32,
+    pub rsvd: [NvU8; 16usize],
+    pub data: ClockClientClkVfPointControlDataV1,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union ClockClientClkVfPointControlDataV1 {
+    pub prog: ClockClientClkVfPointControlProgV1,
+    pub rsvd: [NvU8; 16usize],
+}
+
+impl Default for ClockClientClkVfPointControlDataV1 {
+    fn default() -> Self {
+        Self { rsvd: [0; 16] }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ClockClientClkVfPointControlProgV1 {
+    pub freq_offset_khz: NvS32,
+}
+
+#[allow(clippy::cast_possible_truncation)]
+const fn make_version<T>(version: usize) -> u32 {
+    (mem::size_of::<T>() | (version << 16)) as u32
 }

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -571,7 +571,9 @@ impl<'a> Handler {
         }
 
         self.edit_gpu_config(id.to_owned(), |gpu_config| {
-            gpu_config.apply_clocks_command(&command);
+            gpu_config
+                .clocks_configuration
+                .apply_clocks_command(&command);
         })
         .await
         .context("Failed to edit GPU config and set clocks value")
@@ -584,7 +586,9 @@ impl<'a> Handler {
     ) -> anyhow::Result<u64> {
         self.edit_gpu_config(id.to_owned(), |gpu_config| {
             for command in commands {
-                gpu_config.apply_clocks_command(&command);
+                gpu_config
+                    .clocks_configuration
+                    .apply_clocks_command(&command);
             }
         })
         .await

--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -172,6 +172,7 @@ vf-active-curve = Active Curve
 vf-base-curve = Base Curve
 vf-curve-visible-range = Visible Range (%):
 vf-curve-visible-range-to = to
+vf-curve-flatten-right = Flatten curve to the right
 
 gpu-clock-offset = GPU Clock Offset (MHz)
 max-gpu-clock = Maximum GPU Clock (MHz)

--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -170,6 +170,8 @@ voltage = Voltage
 frequency = Frequency
 vf-active-curve = Active Curve
 vf-base-curve = Base Curve
+vf-curve-visible-range = Visible Range (%):
+vf-curve-visible-range-to = to
 
 gpu-clock-offset = GPU Clock Offset (MHz)
 max-gpu-clock = Maximum GPU Clock (MHz)

--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -143,15 +143,13 @@ power-profile-mode = Power Profile Mode:
 manual-level-needed = Performance level has to be set to "manual" to use power states and modes
 
 overclock-section = Clockspeed and Voltage
-nvidia-oc-info = Nvidia Overclocking Information
+nvidia-oc-info = Overclocking Information
 nvidia-oc-description = 
     Overclocking functionality on Nvidia includes setting offsets for GPU/VRAM clockspeeds and limiting the potential range of clockspeeds using the "locked clocks" feature.
 
     On many cards, the VRAM clockpeed offset will only affect the actual memory clockspeed by half of the offset value.
     For example, a +1000MHz VRAM offset may only increase the measured VRAM speed by 500MHz.
     This is normal, and is how Nvidia handles GDDR data rates. Adjust your overclock accordingly.
-
-    Direct voltage control is not supported, as it does not exist in the Nvidia Linux driver.
 
     It is possible to achieve a pseudo-undervolt by combining the locked clocks option with a positive clockspeed offset.
     This will force the GPU to run at a voltage that's constrained by the locked clocks, while achieving a higher clockspeed due to the offset.
@@ -163,6 +161,15 @@ enable-vram-locked-clocks = Enable VRAM Locked Clocks
 pstate-list-description = <b>The following values are clock offsets for each P-State, going from highest to lowest.</b>
 no-clocks-data = No clocks data available
 reset-oc-tooltip = Warning: this resets all clock settings to defaults!
+vf-curve-editor = VF Curve Editor
+nvidia-vf-curve-warning = The voltage-frequency curve editor relies on undocumented driver functionality. 
+    There are no guarantees regarding its behaviour, safety or availability.
+    <span weight = "heavy" underline = "single">Use at your own risk</span>.
+vf-curve-enable-editing = Enable Editing
+voltage = Voltage
+frequency = Frequency
+vf-active-curve = Active Curve
+vf-base-curve = Base Curve
 
 gpu-clock-offset = GPU Clock Offset (MHz)
 max-gpu-clock = Maximum GPU Clock (MHz)

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -1133,13 +1133,9 @@ impl AppModel {
 
         self.thermals_page.model().apply_config(&mut gpu_config);
 
-        let clocks_commands = self.oc_page.model().get_clocks_commands();
-
-        debug!("applying clocks commands {clocks_commands:#?}");
-
-        for command in clocks_commands {
-            gpu_config.apply_clocks_command(&command);
-        }
+        self.oc_page
+            .model()
+            .apply_clocks_config(&mut gpu_config.clocks_configuration);
 
         let enabled_power_states = self.oc_page.model().get_enabled_power_states();
         gpu_config.power_states = enabled_power_states;

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -494,6 +494,8 @@ impl AsyncComponent for AppModel {
             }
         ));
 
+        let settings_changed = BoolBinding::new(false);
+
         let system_info = daemon_client
             .get_system_info()
             .await
@@ -516,7 +518,7 @@ impl AsyncComponent for AppModel {
         let info_page = InformationPage::detach_default();
 
         let oc_page = OcPage::builder()
-            .launch(system_info.clone())
+            .launch((system_info.clone(), settings_changed.clone()))
             .forward(sender.input_sender(), |msg| msg);
         let thermals_page = ThermalsPage::builder().launch(system_info.clone()).detach();
 
@@ -565,7 +567,7 @@ impl AsyncComponent for AppModel {
             ui_sensitive: BoolBinding::new(false),
             selected_gpu_index: 0,
             stats_task_handle: None,
-            settings_changed: BoolBinding::new(false),
+            settings_changed,
             system_info,
             device_flags: vec![],
         };
@@ -1221,6 +1223,8 @@ impl AppModel {
                 sender.input(AppMsg::ReloadData { full: false });
             }
         ));
+
+        window.present();
     }
 
     async fn dump_vbios(&self, gpu_id: &str, root: &adw::ApplicationWindow) {

--- a/lact-gui/src/app/ext.rs
+++ b/lact-gui/src/app/ext.rs
@@ -20,10 +20,16 @@ impl FlowBoxExt for FlowBox {
 }
 pub trait RelmDefaultLauchable: Component {
     fn detach_default() -> relm4::Controller<Self>;
+
+    fn launch_default() -> relm4::component::Connector<Self>;
 }
 
 impl<S: Default, T: Component<Init = S>> RelmDefaultLauchable for T {
     fn detach_default() -> relm4::Controller<Self> {
         Self::builder().launch(S::default()).detach()
+    }
+
+    fn launch_default() -> relm4::component::Connector<Self> {
+        Self::builder().launch(S::default())
     }
 }

--- a/lact-gui/src/app/graphs_window/plot/mod.rs
+++ b/lact-gui/src/app/graphs_window/plot/mod.rs
@@ -8,7 +8,10 @@ use gtk::{
     glib::{self, Object, subclass::types::ObjectSubclassIsExt},
     prelude::StyleContextExt,
 };
-use plotters::style::{BLACK, Color, RGBAColor, WHITE, full_palette::DEEPORANGE_100};
+use plotters::style::{
+    BLACK, BLUE, Color, RGBAColor, WHITE,
+    full_palette::{DEEPORANGE_100, GREEN_500},
+};
 use std::sync::{Arc, RwLock};
 
 glib::wrapper! {
@@ -49,6 +52,8 @@ pub struct PlotColorScheme {
     pub border: RGBAColor,
     pub border_secondary: RGBAColor,
     pub throttling: RGBAColor,
+    pub success: RGBAColor,
+    pub accent_bg: RGBAColor,
 }
 
 impl Default for PlotColorScheme {
@@ -59,6 +64,8 @@ impl Default for PlotColorScheme {
             border: BLACK.mix(0.8),
             border_secondary: BLACK.mix(0.5),
             throttling: DEEPORANGE_100.into(),
+            success: GREEN_500.into(),
+            accent_bg: BLUE.mix(0.5),
         }
     }
 }
@@ -72,8 +79,12 @@ impl PlotColorScheme {
         let text = lookup_color(ctx, &["theme_text_color"])?;
         let border = lookup_color(ctx, &["borders"])?;
         let border_secondary = lookup_color(ctx, &["unfocused_borders"])?;
+
         let mut throttling = lookup_color(ctx, &["theme_unfocused_fg_color"])?;
         throttling.3 = 0.5;
+
+        let success = lookup_color(ctx, &["success_color"])?;
+        let accent_fg = lookup_color(ctx, &["accent_bg_color"])?;
 
         Some(PlotColorScheme {
             background,
@@ -81,6 +92,8 @@ impl PlotColorScheme {
             border,
             border_secondary,
             throttling,
+            success,
+            accent_bg: accent_fg,
         })
     }
 }
@@ -96,9 +109,9 @@ fn lookup_color(ctx: &gtk::StyleContext, names: &[&str]) -> Option<RGBAColor> {
 
 fn gtk_to_plotters_color(color: gtk::gdk::RGBA) -> RGBAColor {
     RGBAColor(
-        (color.blue() * u8::MAX as f32) as u8,
-        (color.green() * u8::MAX as f32) as u8,
         (color.red() * u8::MAX as f32) as u8,
+        (color.green() * u8::MAX as f32) as u8,
+        (color.blue() * u8::MAX as f32) as u8,
         color.alpha() as f64,
     )
 }

--- a/lact-gui/src/app/graphs_window/plot/mod.rs
+++ b/lact-gui/src/app/graphs_window/plot/mod.rs
@@ -9,7 +9,7 @@ use gtk::{
     prelude::StyleContextExt,
 };
 use plotters::style::{
-    BLACK, BLUE, Color, RGBAColor, WHITE,
+    BLACK, BLUE, Color, RED, RGBAColor, WHITE, YELLOW,
     full_palette::{DEEPORANGE_100, GREEN_500},
 };
 use std::sync::{Arc, RwLock};
@@ -54,6 +54,8 @@ pub struct PlotColorScheme {
     pub throttling: RGBAColor,
     pub success: RGBAColor,
     pub accent_bg: RGBAColor,
+    pub error: RGBAColor,
+    pub warning: RGBAColor,
 }
 
 impl Default for PlotColorScheme {
@@ -66,6 +68,8 @@ impl Default for PlotColorScheme {
             throttling: DEEPORANGE_100.into(),
             success: GREEN_500.into(),
             accent_bg: BLUE.mix(0.5),
+            error: RED.into(),
+            warning: YELLOW.into(),
         }
     }
 }
@@ -85,6 +89,8 @@ impl PlotColorScheme {
 
         let success = lookup_color(ctx, &["success_color"])?;
         let accent_fg = lookup_color(ctx, &["accent_bg_color"])?;
+        let error = lookup_color(ctx, &["error_color"])?;
+        let warning = lookup_color(ctx, &["warning_color"])?;
 
         Some(PlotColorScheme {
             background,
@@ -94,6 +100,8 @@ impl PlotColorScheme {
             throttling,
             success,
             accent_bg: accent_fg,
+            error,
+            warning,
         })
     }
 }

--- a/lact-gui/src/app/graphs_window/plot/render_thread.rs
+++ b/lact-gui/src/app/graphs_window/plot/render_thread.rs
@@ -18,6 +18,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use thread_priority::{ThreadBuilderExt, ThreadPriority};
 use tracing::error;
 
+#[allow(clippy::large_enum_variant)]
 enum Request {
     Terminate,
     Render(RenderRequest),

--- a/lact-gui/src/app/pages/oc_page.rs
+++ b/lact-gui/src/app/pages/oc_page.rs
@@ -3,9 +3,11 @@ pub mod gpu_stats_section;
 mod performance_frame;
 mod power_cap_section;
 mod power_states;
+mod vf_curve;
 
 use super::PageUpdate;
 use crate::app::pages::oc_page::gpu_stats_section::GpuStatsSectionMsg;
+use crate::app::pages::oc_page::vf_curve::{VfCurveEditor, VfCurveEditorMsg};
 use crate::{
     I18N,
     app::{ext::RelmDefaultLauchable, msg::AppMsg},
@@ -21,12 +23,14 @@ use gtk::{
 };
 use i18n_embed_fl::fl;
 use indexmap::IndexMap;
-use lact_schema::{ClocksTable, DeviceInfo, PowerStates, SystemInfo, request::SetClocksCommand};
+use lact_schema::config;
+use lact_schema::{ClocksTable, DeviceInfo, PowerStates, SystemInfo};
 use performance_frame::{PerformanceFrame, PerformanceFrameMsg};
 use power_cap_section::{PowerCapMsg, PowerCapSection};
 use power_states::power_states_frame::{PowerStatesFrame, PowerStatesFrameMsg};
 use relm4::{ComponentController, ComponentParts, ComponentSender, RelmWidgetExt};
 use std::sync::Arc;
+use tracing::debug;
 
 pub struct OcPage {
     stats_section: relm4::Controller<GpuStatsSection>,
@@ -37,6 +41,8 @@ pub struct OcPage {
     power_cap_section: relm4::Controller<PowerCapSection>,
     power_states_frame: relm4::Controller<PowerStatesFrame>,
     clocks_frame: relm4::Controller<ClocksFrame>,
+
+    vf_curve_editor: relm4::Controller<VfCurveEditor>,
 }
 
 #[derive(Debug)]
@@ -117,6 +123,8 @@ impl relm4::Component for OcPage {
             .launch(())
             .forward(sender.input_sender(), |msg| msg);
 
+        let vf_curve_editor = VfCurveEditor::detach_default();
+
         let model = Self {
             stats_section,
             device_info: None,
@@ -125,6 +133,7 @@ impl relm4::Component for OcPage {
             power_cap_section,
             power_states_frame,
             clocks_frame,
+            vf_curve_editor,
         };
 
         let widgets = view_output!();
@@ -147,6 +156,9 @@ impl relm4::Component for OcPage {
 
                     self.stats_section
                         .emit(GpuStatsSectionMsg::Stats(stats.clone()));
+
+                    self.vf_curve_editor
+                        .emit(VfCurveEditorMsg::Stats(stats.clone()));
 
                     if initial {
                         self.power_cap_section
@@ -178,7 +190,12 @@ impl relm4::Component for OcPage {
                 }
             },
             OcPageMsg::ClocksTable(table) => {
-                self.clocks_frame.emit(ClocksFrameMsg::Clocks(table));
+                let table = table.map(Arc::new);
+
+                self.clocks_frame
+                    .emit(ClocksFrameMsg::Clocks(table.clone()));
+                self.vf_curve_editor
+                    .emit(VfCurveEditorMsg::Clocks(table.clone()));
             }
             OcPageMsg::ProfileModesTable(modes_table) => {
                 self.performance_frame
@@ -235,8 +252,16 @@ impl OcPage {
         self.power_cap_section.model().get_user_cap()
     }
 
-    pub fn get_clocks_commands(&self) -> Vec<SetClocksCommand> {
-        self.clocks_frame.model().get_commands()
+    pub fn apply_clocks_config(&self, config: &mut config::ClocksConfiguration) {
+        let commands = self.clocks_frame.model().get_commands();
+
+        debug!("applying clocks commands {commands:#?}");
+
+        for command in commands {
+            config.apply_clocks_command(&command);
+        }
+
+        config.gpu_vf_curve = self.vf_curve_editor.model().get_configured_curve();
     }
 
     pub fn get_enabled_power_states(&self) -> IndexMap<PowerLevelKind, Vec<u8>> {

--- a/lact-gui/src/app/pages/oc_page.rs
+++ b/lact-gui/src/app/pages/oc_page.rs
@@ -28,6 +28,7 @@ use lact_schema::{ClocksTable, DeviceInfo, PowerStates, SystemInfo};
 use performance_frame::{PerformanceFrame, PerformanceFrameMsg};
 use power_cap_section::{PowerCapMsg, PowerCapSection};
 use power_states::power_states_frame::{PowerStatesFrame, PowerStatesFrameMsg};
+use relm4::binding::BoolBinding;
 use relm4::{ComponentController, ComponentParts, ComponentSender, RelmWidgetExt};
 use std::sync::Arc;
 use tracing::debug;
@@ -58,11 +59,12 @@ pub enum OcPageMsg {
         configured: bool,
     },
     PerformanceLevelChanged,
+    ShowVfCurveEditor,
 }
 
 #[relm4::component(pub)]
 impl relm4::Component for OcPage {
-    type Init = SystemInfo;
+    type Init = (SystemInfo, BoolBinding);
     type Input = OcPageMsg;
     type Output = AppMsg;
     type CommandOutput = ();
@@ -111,19 +113,18 @@ impl relm4::Component for OcPage {
     }
 
     fn init(
-        system_info: Self::Init,
+        (system_info, settings_changed): Self::Init,
         root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let stats_section = GpuStatsSection::detach_default();
         let power_cap_section = PowerCapSection::detach_default();
-        let clocks_frame = ClocksFrame::detach_default();
+        let clocks_frame = ClocksFrame::launch_default().forward(sender.input_sender(), |msg| msg);
         let power_states_frame = PowerStatesFrame::detach_default();
-        let performance_frame = PerformanceFrame::builder()
-            .launch(())
-            .forward(sender.input_sender(), |msg| msg);
+        let performance_frame =
+            PerformanceFrame::launch_default().forward(sender.input_sender(), |msg| msg);
 
-        let vf_curve_editor = VfCurveEditor::detach_default();
+        let vf_curve_editor = VfCurveEditor::builder().launch(settings_changed).detach();
 
         let model = Self {
             stats_section,
@@ -226,6 +227,9 @@ impl relm4::Component for OcPage {
                     .emit(PowerStatesFrameMsg::PerformanceLevel(
                         self.get_performance_level(),
                     ));
+            }
+            OcPageMsg::ShowVfCurveEditor => {
+                self.vf_curve_editor.emit(VfCurveEditorMsg::Show);
             }
         }
 

--- a/lact-gui/src/app/pages/oc_page/clocks_frame.rs
+++ b/lact-gui/src/app/pages/oc_page/clocks_frame.rs
@@ -35,6 +35,7 @@ pub struct ClocksFrame {
     vram_groups: FactoryHashMap<ClockCategory, AdjustmentGroup>,
     vram_clock_ratio: f64,
     show_nvidia_options: bool,
+    vf_curve_available: bool,
     show_all_pstates: BoolBinding,
     enable_gpu_locked_clocks: BoolBinding,
     enable_vram_locked_clocks: BoolBinding,
@@ -85,7 +86,7 @@ impl relm4::Component for ClocksFrame {
                     add_css_class: css::WARNING,
 
                     #[watch]
-                    set_visible: model.show_nvidia_options,
+                    set_visible: model.show_nvidia_options && model.vf_curve_available,
 
                     connect_clicked[sender] => move |_| {
                         sender.output(OcPageMsg::ShowVfCurveEditor).unwrap();
@@ -226,6 +227,7 @@ impl relm4::Component for ClocksFrame {
             vram_groups: FactoryHashMap::builder().launch_default().detach(),
             vram_clock_ratio: 1.0,
             show_nvidia_options: false,
+            vf_curve_available: false,
             show_all_pstates: BoolBinding::new(false),
             enable_gpu_locked_clocks: BoolBinding::new(false),
             enable_vram_locked_clocks: BoolBinding::new(false),
@@ -550,6 +552,7 @@ impl ClocksFrame {
 
     fn set_nvidia_table(&mut self, table: &NvidiaClocksTable) {
         self.show_nvidia_options = true;
+        self.vf_curve_available = !table.gpu_vf_curve.is_empty();
 
         let locked_clocks = [
             (

--- a/lact-gui/src/app/pages/oc_page/clocks_frame.rs
+++ b/lact-gui/src/app/pages/oc_page/clocks_frame.rs
@@ -4,8 +4,9 @@ mod adjustment_row;
 use crate::{
     APP_BROKER, I18N,
     app::{
-        msg::AppMsg, page_section::PageSection,
-        pages::oc_page::clocks_frame::adjustment_group::AdjustmentGroup,
+        msg::AppMsg,
+        page_section::PageSection,
+        pages::oc_page::{OcPageMsg, clocks_frame::adjustment_group::AdjustmentGroup},
     },
 };
 use adjustment_group::ClockCategory;
@@ -50,7 +51,7 @@ pub enum ClocksFrameMsg {
 impl relm4::Component for ClocksFrame {
     type Init = ();
     type Input = ClocksFrameMsg;
-    type Output = ();
+    type Output = OcPageMsg;
     type CommandOutput = ();
 
     view! {
@@ -76,6 +77,18 @@ impl relm4::Component for ClocksFrame {
                             set_wrap: true,
                             set_max_width_chars: 75,
                         }
+                    }
+                },
+
+                append = &gtk::Button {
+                    set_label: &fl!(I18N, "vf-curve-editor"),
+                    add_css_class: css::WARNING,
+
+                    #[watch]
+                    set_visible: model.show_nvidia_options,
+
+                    connect_clicked[sender] => move |_| {
+                        sender.output(OcPageMsg::ShowVfCurveEditor).unwrap();
                     }
                 },
 

--- a/lact-gui/src/app/pages/oc_page/clocks_frame.rs
+++ b/lact-gui/src/app/pages/oc_page/clocks_frame.rs
@@ -25,6 +25,7 @@ use relm4::{
     ComponentParts, ComponentSender, RelmObjectExt, RelmWidgetExt, binding::BoolBinding, css,
     factory::FactoryHashMap,
 };
+use std::sync::Arc;
 
 const DEFAULT_VOLTAGE_OFFSET_RANGE: i32 = 250;
 
@@ -40,7 +41,7 @@ pub struct ClocksFrame {
 
 #[derive(Debug)]
 pub enum ClocksFrameMsg {
-    Clocks(Option<ClocksTable>),
+    Clocks(Option<Arc<ClocksTable>>),
     VramRatio(f64),
     TogglePStatesVisibility,
 }
@@ -260,7 +261,7 @@ impl relm4::Component for ClocksFrame {
                 self.show_nvidia_options = false;
 
                 if let Some(table) = clocks_table {
-                    match table {
+                    match table.as_ref() {
                         ClocksTable::Amd(table) => self.set_amd_table(table),
                         ClocksTable::Nvidia(table) => self.set_nvidia_table(table),
                         ClocksTable::Intel(table) => self.set_intel_table(table),
@@ -352,7 +353,7 @@ impl ClocksFrame {
         }
     }
 
-    fn set_amd_table(&mut self, table: AmdClocksTable) {
+    fn set_amd_table(&mut self, table: &AmdClocksTable) {
         match table {
             AmdClocksTable::Gcn(table) => {
                 let vddc_range = table.od_range.vddc.and_then(|range| range.into_full());
@@ -534,7 +535,7 @@ impl ClocksFrame {
         }
     }
 
-    fn set_nvidia_table(&mut self, table: NvidiaClocksTable) {
+    fn set_nvidia_table(&mut self, table: &NvidiaClocksTable) {
         self.show_nvidia_options = true;
 
         let locked_clocks = [
@@ -575,21 +576,21 @@ impl ClocksFrame {
             }
         }
 
-        for (pstate, offset) in table.gpu_offsets {
+        for (pstate, offset) in &table.gpu_offsets {
             self.set_clock(
-                ClockspeedType::GpuClockOffset(pstate),
-                nvidia_clock_offset_to_data(&offset, pstate > 0),
+                ClockspeedType::GpuClockOffset(*pstate),
+                nvidia_clock_offset_to_data(offset, *pstate > 0),
             );
         }
-        for (pstate, offset) in table.mem_offsets {
+        for (pstate, offset) in &table.mem_offsets {
             self.set_clock(
-                ClockspeedType::MemClockOffset(pstate),
-                nvidia_clock_offset_to_data(&offset, pstate > 0),
+                ClockspeedType::MemClockOffset(*pstate),
+                nvidia_clock_offset_to_data(offset, *pstate > 0),
             );
         }
     }
 
-    fn set_intel_table(&mut self, table: IntelClocksTable) {
+    fn set_intel_table(&mut self, table: &IntelClocksTable) {
         self.show_all_pstates.set_value(false);
 
         if let Some((current_gt_min, current_gt_max)) = table.gt_freq

--- a/lact-gui/src/app/pages/oc_page/vf_curve.rs
+++ b/lact-gui/src/app/pages/oc_page/vf_curve.rs
@@ -1,11 +1,16 @@
-use crate::app::{APP_BROKER, graphs_window::plot::PlotColorScheme, msg::AppMsg};
+use crate::{
+    I18N,
+    app::{APP_BROKER, graphs_window::plot::PlotColorScheme, msg::AppMsg},
+};
 use gtk::{
     gdk,
     prelude::{
-        ButtonExt as _, DrawingAreaExtManual as _, EventControllerExt as _, GestureSingleExt as _,
-        GtkWindowExt as _, PopoverExt, WidgetExt as _,
+        BoxExt as _, ButtonExt as _, CheckButtonExt as _, DrawingAreaExtManual as _,
+        EventControllerExt as _, GestureSingleExt as _, GtkWindowExt as _, OrientableExt as _,
+        PopoverExt, WidgetExt as _,
     },
 };
+use i18n_embed_fl::fl;
 use indexmap::IndexMap;
 use lact_schema::{ClocksTable, DeviceStats, NvidiaVfPoint, config};
 use plotters::{
@@ -15,7 +20,7 @@ use plotters::{
     style::{Color as _, ShapeStyle, TextStyle, text_anchor::Pos},
 };
 use plotters_cairo::CairoBackend;
-use relm4::{ComponentParts, RelmWidgetExt as _};
+use relm4::{ComponentParts, RelmObjectExt as _, RelmWidgetExt as _, binding::BoolBinding, css};
 use std::fmt::Write as _;
 use std::{
     cell::{Cell, RefCell},
@@ -31,6 +36,10 @@ const POINT_FREQ_HOVER_MARGIN: f32 = 0.03;
 pub struct VfCurveEditor {
     points: Rc<RefCell<Vec<NvidiaVfPoint>>>,
     stats: Rc<RefCell<Arc<DeviceStats>>>,
+    allow_editing: BoolBinding,
+
+    // Passed from app
+    global_settings_changed: BoolBinding,
 
     cursor_position: Rc<Cell<Option<(f64, f64)>>>,
     hovered_point: Rc<Cell<Option<usize>>>,
@@ -40,6 +49,7 @@ pub struct VfCurveEditor {
 
 #[derive(Debug)]
 pub enum VfCurveEditorMsg {
+    Show,
     Clocks(Option<Arc<ClocksTable>>),
     Stats(Arc<DeviceStats>),
     CursorUpdate {
@@ -50,11 +60,12 @@ pub enum VfCurveEditorMsg {
     DragStart,
     DragEnd,
     FlattenCurve,
+    ResetCurve,
 }
 
 #[relm4::component(pub)]
 impl relm4::Component for VfCurveEditor {
-    type Init = ();
+    type Init = BoolBinding;
     type Input = VfCurveEditorMsg;
     type Output = ();
     type CommandOutput = ();
@@ -64,16 +75,36 @@ impl relm4::Component for VfCurveEditor {
         adw::Window {
             set_hide_on_close: true,
             set_default_size: (1100, 700),
-            set_title: Some("VF Curve Editor"),
+            set_title: Some(&fl!(I18N, "vf-curve-editor")),
 
             adw::ToolbarView {
                 add_top_bar = &adw::HeaderBar {},
 
                 #[wrap(Some)]
                 set_content = &gtk::Box {
+                    set_orientation: gtk::Orientation::Vertical,
+                    set_margin_all: 5,
+                    set_spacing: 10,
+
+                    gtk::Box {
+                        set_orientation: gtk::Orientation::Horizontal,
+                        set_halign: gtk::Align::Center,
+                        set_spacing: 10,
+
+                        gtk::Label {
+                            set_markup: &fl!(I18N, "nvidia-vf-curve-warning"),
+                            add_css_class: "error",
+                            add_css_class: "heading",
+                        },
+
+                    },
+
+
                     #[name = "drawing_area"]
                     gtk::DrawingArea {
                         set_expand: true,
+                        set_margin_all: 10,
+
                         set_draw_func[model] => move |area, ctx, width, height| {
                             let style_context = area.style_context();
                             let colors = PlotColorScheme::from_context(&style_context).unwrap_or_default();
@@ -121,6 +152,49 @@ impl relm4::Component for VfCurveEditor {
                         }.as_ref(),
                     },
 
+                    gtk::Box {
+                        set_orientation: gtk::Orientation::Horizontal,
+                        set_halign: gtk::Align::End,
+                        set_spacing: 5,
+
+                        gtk::CheckButton {
+                            set_label: Some(&fl!(I18N, "vf-curve-enable-editing")),
+                            add_css_class: "warning",
+                            add_binding: (&model.allow_editing, "active"),
+
+                            connect_toggled => move |_| {
+                                APP_BROKER.send(AppMsg::SettingsChanged);
+                            }
+                        },
+
+                        gtk::Button {
+                            set_label: &fl!(I18N, "reset-button"),
+                            add_css_class: css::DESTRUCTIVE_ACTION,
+
+                            #[watch]
+                            set_sensitive: {
+                                model.points.borrow()
+                                    .iter()
+                                    .any(|point| point.freq != point.base_freq)
+                            },
+
+                            connect_clicked => VfCurveEditorMsg::ResetCurve,
+                            connect_clicked => move |_| {
+                                APP_BROKER.send(AppMsg::SettingsChanged);
+                            }
+                        },
+
+
+                        gtk::Button {
+                            set_label: &fl!(I18N, "apply-button"),
+                            add_binding: (&model.global_settings_changed, "sensitive"),
+                            add_css_class: css::SUGGESTED_ACTION,
+
+                            connect_clicked => move |_| {
+                                APP_BROKER.send(AppMsg::ApplyChanges);
+                            },
+                        },
+                    },
                 },
             },
         },
@@ -145,13 +219,15 @@ impl relm4::Component for VfCurveEditor {
     }
 
     fn init(
-        _init: Self::Init,
+        global_settings_changed: Self::Init,
         root: Self::Root,
         sender: relm4::ComponentSender<Self>,
     ) -> relm4::ComponentParts<Self> {
         let model = Self {
             points: Rc::default(),
             stats: Rc::default(),
+            global_settings_changed,
+            allow_editing: BoolBinding::new(false),
             cursor_position: Rc::new(Cell::new(None)),
             hovered_point: Rc::new(Cell::new(None)),
             dragging_point: Rc::new(Cell::new(None)),
@@ -159,8 +235,6 @@ impl relm4::Component for VfCurveEditor {
         };
 
         let widgets = view_output!();
-
-        root.present();
 
         ComponentParts { model, widgets }
     }
@@ -173,6 +247,9 @@ impl relm4::Component for VfCurveEditor {
         root: &Self::Root,
     ) {
         match msg {
+            VfCurveEditorMsg::Show => {
+                root.present();
+            }
             VfCurveEditorMsg::Clocks(clocks_table) => {
                 let mut points = self.points.borrow_mut();
                 points.clear();
@@ -193,7 +270,9 @@ impl relm4::Component for VfCurveEditor {
                 self.drag_modifiers.set(modifiers);
             }
             VfCurveEditorMsg::DragStart => {
-                if let Some(point) = self.hovered_point.get() {
+                if let Some(point) = self.hovered_point.get()
+                    && self.allow_editing.value()
+                {
                     self.dragging_point.set(Some(point));
                 }
             }
@@ -216,6 +295,12 @@ impl relm4::Component for VfCurveEditor {
                     }
 
                     APP_BROKER.send(AppMsg::SettingsChanged);
+                }
+            }
+            VfCurveEditorMsg::ResetCurve => {
+                let mut points = self.points.borrow_mut();
+                for point in points.iter_mut() {
+                    point.freq = point.base_freq;
                 }
             }
         }
@@ -266,8 +351,8 @@ impl VfCurveEditor {
             .y_label_formatter(&|clock| format!("{clock} MHz"))
             .x_label_style(("sans-serif", 14, &colors.text))
             .y_label_style(("sans-serif", 14, &colors.text))
-            .x_desc("Voltage")
-            .y_desc("Clockspeed")
+            .x_desc(fl!(I18N, "voltage"))
+            .y_desc(fl!(I18N, "frequency"))
             .draw()
             .unwrap();
 
@@ -277,7 +362,7 @@ impl VfCurveEditor {
                 &colors.success,
             ))
             .unwrap()
-            .label("Active Curve")
+            .label(fl!(I18N, "vf-active-curve"))
             .legend(move |(x, y)| {
                 Rectangle::new([(x - 15, y + 2), (x, y - 1)], colors.success.filled())
             });
@@ -290,7 +375,7 @@ impl VfCurveEditor {
                     &base_line_style,
                 ))
                 .unwrap()
-                .label("Base Curve")
+                .label(fl!(I18N, "vf-base-curve"))
                 .legend(move |(x, y)| {
                     Rectangle::new([(x - 15, y + 2), (x, y - 1)], base_line_style.filled())
                 });
@@ -478,6 +563,10 @@ impl VfCurveEditor {
     }
 
     pub fn get_configured_curve(&self) -> IndexMap<u8, config::CurvePoint> {
+        if !self.allow_editing.value() {
+            return IndexMap::new();
+        }
+
         self.points
             .borrow()
             .iter()

--- a/lact-gui/src/app/pages/oc_page/vf_curve.rs
+++ b/lact-gui/src/app/pages/oc_page/vf_curve.rs
@@ -189,6 +189,7 @@ impl relm4::Component for VfCurveEditor {
                         gtk::CheckButton {
                             set_label: Some(&fl!(I18N, "vf-curve-enable-editing")),
                             set_halign: gtk::Align::End,
+                            set_valign: gtk::Align::Center,
                             set_hexpand: true,
                             add_css_class: "warning",
                             add_binding: (&model.allow_editing, "active"),
@@ -202,6 +203,7 @@ impl relm4::Component for VfCurveEditor {
                             set_label: &fl!(I18N, "reset-button"),
                             set_halign: gtk::Align::End,
                             add_css_class: css::DESTRUCTIVE_ACTION,
+                            set_valign: gtk::Align::Center,
 
                             #[watch]
                             set_sensitive: {
@@ -222,6 +224,7 @@ impl relm4::Component for VfCurveEditor {
                             set_halign: gtk::Align::End,
                             add_binding: (&model.global_settings_changed, "sensitive"),
                             add_css_class: css::SUGGESTED_ACTION,
+                            set_valign: gtk::Align::Center,
 
                             connect_clicked => move |_| {
                                 APP_BROKER.send(AppMsg::ApplyChanges);

--- a/lact-gui/src/app/pages/oc_page/vf_curve.rs
+++ b/lact-gui/src/app/pages/oc_page/vf_curve.rs
@@ -130,7 +130,7 @@ impl relm4::Component for VfCurveEditor {
                         add_controller = gtk::GestureClick {
                             set_button: gdk::BUTTON_SECONDARY,
                             connect_pressed[drawing_area, point_menu, model] => move |_, _, x, y| {
-                                if model.hovered_point.get().is_none() {
+                                if model.hovered_point.get().is_none() || !model.allow_editing.value() {
                                     return;
                                 }
 
@@ -241,7 +241,7 @@ impl relm4::Component for VfCurveEditor {
             },
 
             gtk::Button {
-                set_label: "Flatten curve to the right",
+                set_label: &fl!(I18N, "vf-curve-flatten-right"),
                 connect_clicked => VfCurveEditorMsg::FlattenCurve,
                 connect_clicked[point_menu] => move |_| {
                     point_menu.popdown();

--- a/lact-gui/src/app/pages/oc_page/vf_curve.rs
+++ b/lact-gui/src/app/pages/oc_page/vf_curve.rs
@@ -1,7 +1,9 @@
 use crate::app::{APP_BROKER, graphs_window::plot::PlotColorScheme, msg::AppMsg};
 use gtk::{
     gdk,
-    prelude::{DrawingAreaExtManual as _, GtkWindowExt as _, WidgetExt as _},
+    prelude::{
+        DrawingAreaExtManual as _, EventControllerExt as _, GtkWindowExt as _, WidgetExt as _,
+    },
 };
 use indexmap::IndexMap;
 use lact_schema::{ClocksTable, DeviceStats, NvidiaVfPoint, config};
@@ -32,13 +34,18 @@ pub struct VfCurveEditor {
     cursor_position: Rc<Cell<Option<(f64, f64)>>>,
     hovered_point: Rc<Cell<Option<usize>>>,
     dragging_point: Rc<Cell<Option<usize>>>,
+    drag_modifiers: Rc<Cell<gdk::ModifierType>>,
 }
 
 #[derive(Debug)]
 pub enum VfCurveEditorMsg {
     Clocks(Option<Arc<ClocksTable>>),
     Stats(Arc<DeviceStats>),
-    CursorUpdate(f64, f64),
+    CursorUpdate {
+        x: f64,
+        y: f64,
+        modifiers: gdk::ModifierType,
+    },
     DragStart,
     DragEnd,
 }
@@ -71,9 +78,11 @@ impl relm4::Component for VfCurveEditor {
                         },
 
                         add_controller = gtk::GestureClick {
-                            connect_pressed[sender] => move |_, _, x, y| {
+                            connect_pressed[sender] => move |gesture, _, x, y| {
+                                let modifiers = gesture.current_event_state();
+
                                 sender.input(VfCurveEditorMsg::DragStart);
-                                sender.input(VfCurveEditorMsg::CursorUpdate(x, y));
+                                sender.input(VfCurveEditorMsg::CursorUpdate { x, y, modifiers });
                             },
                             connect_released[sender] => move |_, _, _x, _y| {
                                 sender.input(VfCurveEditorMsg::DragEnd);
@@ -81,8 +90,9 @@ impl relm4::Component for VfCurveEditor {
                         },
 
                         add_controller = gtk::EventControllerMotion {
-                            connect_motion[sender] => move |_, x, y| {
-                                sender.input(VfCurveEditorMsg::CursorUpdate(x, y));
+                            connect_motion[sender] => move |motion, x, y| {
+                                let modifiers = motion.current_event_state();
+                                sender.input(VfCurveEditorMsg::CursorUpdate { x, y, modifiers });
                             },
                         },
 
@@ -109,6 +119,7 @@ impl relm4::Component for VfCurveEditor {
             cursor_position: Rc::new(Cell::new(None)),
             hovered_point: Rc::new(Cell::new(None)),
             dragging_point: Rc::new(Cell::new(None)),
+            drag_modifiers: Rc::new(Cell::new(gdk::ModifierType::empty())),
         };
 
         let widgets = view_output!();
@@ -141,8 +152,9 @@ impl relm4::Component for VfCurveEditor {
             VfCurveEditorMsg::Stats(device_stats) => {
                 *self.stats.borrow_mut() = device_stats;
             }
-            VfCurveEditorMsg::CursorUpdate(x, y) => {
+            VfCurveEditorMsg::CursorUpdate { x, y, modifiers } => {
                 self.cursor_position.set(Some((x, y)));
+                self.drag_modifiers.set(modifiers);
             }
             VfCurveEditorMsg::DragStart => {
                 if let Some(point) = self.hovered_point.get() {
@@ -391,7 +403,23 @@ impl VfCurveEditor {
         if let Some((_voltage, freq)) = hovered_coords
             && let Some(point_idx) = self.dragging_point.get()
         {
-            points[point_idx].freq = freq.clamp(freq_range.start, freq_range.end);
+            let new_freq = freq.clamp(freq_range.start, freq_range.end);
+            let drag_delta = new_freq as i32 - points[point_idx].freq as i32;
+
+            if self
+                .drag_modifiers
+                .get()
+                .contains(gdk::ModifierType::SHIFT_MASK)
+            {
+                for point in points.iter_mut() {
+                    let new_freq = (point.freq as i32 + drag_delta) as u32;
+                    if new_freq > 0 {
+                        point.freq = new_freq;
+                    }
+                }
+            } else {
+                points[point_idx].freq = new_freq;
+            }
         }
 
         root.present().unwrap();

--- a/lact-gui/src/app/pages/oc_page/vf_curve.rs
+++ b/lact-gui/src/app/pages/oc_page/vf_curve.rs
@@ -2,7 +2,8 @@ use crate::app::{APP_BROKER, graphs_window::plot::PlotColorScheme, msg::AppMsg};
 use gtk::{
     gdk,
     prelude::{
-        DrawingAreaExtManual as _, EventControllerExt as _, GtkWindowExt as _, WidgetExt as _,
+        ButtonExt as _, DrawingAreaExtManual as _, EventControllerExt as _, GestureSingleExt as _,
+        GtkWindowExt as _, PopoverExt, WidgetExt as _,
     },
 };
 use indexmap::IndexMap;
@@ -48,6 +49,7 @@ pub enum VfCurveEditorMsg {
     },
     DragStart,
     DragEnd,
+    FlattenCurve,
 }
 
 #[relm4::component(pub)]
@@ -58,6 +60,7 @@ impl relm4::Component for VfCurveEditor {
     type CommandOutput = ();
 
     view! {
+        #[root]
         adw::Window {
             set_hide_on_close: true,
             set_default_size: (1100, 700),
@@ -71,7 +74,7 @@ impl relm4::Component for VfCurveEditor {
                     #[name = "drawing_area"]
                     gtk::DrawingArea {
                         set_expand: true,
-                        set_draw_func[model = model.clone()] => move |area, ctx, width, height| {
+                        set_draw_func[model] => move |area, ctx, width, height| {
                             let style_context = area.style_context();
                             let colors = PlotColorScheme::from_context(&style_context).unwrap_or_default();
                             model.draw_chart(ctx, width, height, colors);
@@ -89,6 +92,20 @@ impl relm4::Component for VfCurveEditor {
                             }
                         },
 
+                        add_controller = gtk::GestureClick {
+                            set_button: gdk::BUTTON_SECONDARY,
+                            connect_pressed[drawing_area, point_menu, model] => move |_, _, x, y| {
+                                if model.hovered_point.get().is_none() {
+                                    return;
+                                }
+
+                                point_menu.set_parent(&drawing_area);
+                                point_menu.set_pointing_to(Some(&gdk::Rectangle::new(x as i32, y as i32, 1, 1)));
+                                point_menu.popup();
+
+                            },
+                        },
+
                         add_controller = gtk::EventControllerMotion {
                             connect_motion[sender] => move |motion, x, y| {
                                 let modifiers = motion.current_event_state();
@@ -103,7 +120,26 @@ impl relm4::Component for VfCurveEditor {
                             None
                         }.as_ref(),
                     },
+
                 },
+            },
+        },
+
+        #[name = "point_menu"]
+        gtk::Popover {
+            add_css_class: "menu",
+
+            connect_closed => |popover| {
+                popover.unparent();
+            },
+
+            gtk::Button {
+                set_label: "Flatten curve to the right",
+                connect_clicked => VfCurveEditorMsg::FlattenCurve,
+                connect_clicked[point_menu] => move |_| {
+                    point_menu.popdown();
+                },
+                add_css_class: "flat",
             },
         }
     }
@@ -163,6 +199,22 @@ impl relm4::Component for VfCurveEditor {
             }
             VfCurveEditorMsg::DragEnd => {
                 if self.dragging_point.take().is_some() {
+                    APP_BROKER.send(AppMsg::SettingsChanged);
+                }
+            }
+            VfCurveEditorMsg::FlattenCurve => {
+                if let Some(base_point_idx) = self.hovered_point.get() {
+                    let mut points = self.points.borrow_mut();
+                    // TODO
+                    let total_len = points.len();
+                    let points = &mut points[total_len / 3..];
+
+                    let target_freq = points[base_point_idx].freq;
+
+                    for point in points.iter_mut().skip(base_point_idx) {
+                        point.freq = target_freq;
+                    }
+
                     APP_BROKER.send(AppMsg::SettingsChanged);
                 }
             }

--- a/lact-gui/src/app/pages/oc_page/vf_curve.rs
+++ b/lact-gui/src/app/pages/oc_page/vf_curve.rs
@@ -1,0 +1,421 @@
+use crate::app::{APP_BROKER, graphs_window::plot::PlotColorScheme, msg::AppMsg};
+use gtk::{
+    gdk,
+    prelude::{DrawingAreaExtManual as _, GtkWindowExt as _, WidgetExt as _},
+};
+use indexmap::IndexMap;
+use lact_schema::{ClocksTable, DeviceStats, NvidiaVfPoint, config};
+use plotters::{
+    chart::{ChartBuilder, SeriesLabelPosition},
+    prelude::{Circle, EmptyElement, IntoDrawingArea as _, Rectangle, Text},
+    series::{DashedLineSeries, LineSeries, PointSeries},
+    style::{Color as _, ShapeStyle, TextStyle, text_anchor::Pos},
+};
+use plotters_cairo::CairoBackend;
+use relm4::{ComponentParts, RelmWidgetExt as _};
+use std::fmt::Write as _;
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+    sync::Arc,
+};
+
+// In percentage
+const POINT_VOLTAGE_HOVER_MARGIN: f32 = 0.01;
+const POINT_FREQ_HOVER_MARGIN: f32 = 0.03;
+
+#[derive(Clone)]
+pub struct VfCurveEditor {
+    points: Rc<RefCell<Vec<NvidiaVfPoint>>>,
+    stats: Rc<RefCell<Arc<DeviceStats>>>,
+
+    cursor_position: Rc<Cell<Option<(f64, f64)>>>,
+    hovered_point: Rc<Cell<Option<usize>>>,
+    dragging_point: Rc<Cell<Option<usize>>>,
+}
+
+#[derive(Debug)]
+pub enum VfCurveEditorMsg {
+    Clocks(Option<Arc<ClocksTable>>),
+    Stats(Arc<DeviceStats>),
+    CursorUpdate(f64, f64),
+    DragStart,
+    DragEnd,
+}
+
+#[relm4::component(pub)]
+impl relm4::Component for VfCurveEditor {
+    type Init = ();
+    type Input = VfCurveEditorMsg;
+    type Output = ();
+    type CommandOutput = ();
+
+    view! {
+        adw::Window {
+            set_hide_on_close: true,
+            set_default_size: (1100, 700),
+            set_title: Some("VF Curve Editor"),
+
+            adw::ToolbarView {
+                add_top_bar = &adw::HeaderBar {},
+
+                #[wrap(Some)]
+                set_content = &gtk::Box {
+                    #[name = "drawing_area"]
+                    gtk::DrawingArea {
+                        set_expand: true,
+                        set_draw_func[model = model.clone()] => move |area, ctx, width, height| {
+                            let style_context = area.style_context();
+                            let colors = PlotColorScheme::from_context(&style_context).unwrap_or_default();
+                            model.draw_chart(ctx, width, height, colors);
+                        },
+
+                        add_controller = gtk::GestureClick {
+                            connect_pressed[sender] => move |_, _, x, y| {
+                                sender.input(VfCurveEditorMsg::DragStart);
+                                sender.input(VfCurveEditorMsg::CursorUpdate(x, y));
+                            },
+                            connect_released[sender] => move |_, _, _x, _y| {
+                                sender.input(VfCurveEditorMsg::DragEnd);
+                            }
+                        },
+
+                        add_controller = gtk::EventControllerMotion {
+                            connect_motion[sender] => move |_, x, y| {
+                                sender.input(VfCurveEditorMsg::CursorUpdate(x, y));
+                            },
+                        },
+
+                        #[watch]
+                        set_cursor: if model.dragging_point.get().is_some() {
+                            gdk::Cursor::from_name("move", None)
+                        } else {
+                            None
+                        }.as_ref(),
+                    },
+                },
+            },
+        }
+    }
+
+    fn init(
+        _init: Self::Init,
+        root: Self::Root,
+        sender: relm4::ComponentSender<Self>,
+    ) -> relm4::ComponentParts<Self> {
+        let model = Self {
+            points: Rc::default(),
+            stats: Rc::default(),
+            cursor_position: Rc::new(Cell::new(None)),
+            hovered_point: Rc::new(Cell::new(None)),
+            dragging_point: Rc::new(Cell::new(None)),
+        };
+
+        let widgets = view_output!();
+
+        root.present();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update_with_view(
+        &mut self,
+        widgets: &mut Self::Widgets,
+        msg: Self::Input,
+        sender: relm4::ComponentSender<Self>,
+        root: &Self::Root,
+    ) {
+        match msg {
+            VfCurveEditorMsg::Clocks(clocks_table) => {
+                let mut points = self.points.borrow_mut();
+                points.clear();
+
+                if let Some(ClocksTable::Nvidia(nvidia_table)) = clocks_table.as_deref() {
+                    points.extend_from_slice(&nvidia_table.gpu_vf_curve);
+                }
+
+                if points.is_empty() {
+                    root.hide();
+                }
+            }
+            VfCurveEditorMsg::Stats(device_stats) => {
+                *self.stats.borrow_mut() = device_stats;
+            }
+            VfCurveEditorMsg::CursorUpdate(x, y) => {
+                self.cursor_position.set(Some((x, y)));
+            }
+            VfCurveEditorMsg::DragStart => {
+                if let Some(point) = self.hovered_point.get() {
+                    self.dragging_point.set(Some(point));
+                }
+            }
+            VfCurveEditorMsg::DragEnd => {
+                if self.dragging_point.take().is_some() {
+                    APP_BROKER.send(AppMsg::SettingsChanged);
+                }
+            }
+        }
+
+        self.update_view(widgets, sender);
+    }
+
+    fn post_view() {
+        drawing_area.queue_draw();
+    }
+}
+
+impl VfCurveEditor {
+    fn draw_chart(&self, ctx: &cairo::Context, width: i32, height: i32, colors: PlotColorScheme) {
+        let mut points = self.points.borrow_mut();
+
+        if points.is_empty() {
+            return;
+        }
+
+        let total_len = points.len();
+        let points = &mut points[total_len / 3..];
+
+        let backend = CairoBackend::new(ctx, (width as u32, height as u32)).unwrap();
+
+        let root = backend.into_drawing_area();
+        root.fill(&colors.background).unwrap();
+
+        let min_point = points.first().unwrap();
+        let max_point = points.last().unwrap();
+
+        let x_spec = min_point.base_voltage..max_point.base_voltage;
+        let y_spec = min_point.base_freq..(max_point.base_freq as f64 * 1.1) as u32;
+
+        let mut chart = ChartBuilder::on(&root)
+            .x_label_area_size(45)
+            .y_label_area_size(110)
+            .margin(50)
+            .margin_bottom(20)
+            .build_cartesian_2d(x_spec.clone(), y_spec.clone())
+            .unwrap();
+
+        chart
+            .configure_mesh()
+            .axis_style(colors.border_secondary)
+            .bold_line_style(colors.border)
+            .x_label_formatter(&|voltage| format!("{voltage} mV"))
+            .y_label_formatter(&|clock| format!("{clock} MHz"))
+            .x_label_style(("sans-serif", 14, &colors.text))
+            .y_label_style(("sans-serif", 14, &colors.text))
+            .x_desc("Voltage")
+            .y_desc("Clockspeed")
+            .draw()
+            .unwrap();
+
+        chart
+            .draw_series(LineSeries::new(
+                points.iter().map(vf_point_coords),
+                &colors.success,
+            ))
+            .unwrap()
+            .label("Active Curve")
+            .legend(move |(x, y)| {
+                Rectangle::new([(x - 15, y + 2), (x, y - 1)], colors.success.filled())
+            });
+
+        if points.iter().any(|point| point.freq != point.base_freq) {
+            let base_line_style = colors.success.mix(0.3);
+            chart
+                .draw_series(LineSeries::new(
+                    points.iter().map(vf_point_base_coords),
+                    &base_line_style,
+                ))
+                .unwrap()
+                .label("Base Curve")
+                .legend(move |(x, y)| {
+                    Rectangle::new([(x - 15, y + 2), (x, y - 1)], base_line_style.filled())
+                });
+        }
+
+        let mut main_label = None;
+
+        let stats = self.stats.borrow();
+        if let Some(current_voltage) = stats.voltage.gpu
+            && let Some(current_clock) = stats.clockspeed.gpu_clockspeed
+        {
+            let mut label = format!("Current: {current_clock} MHz @ {current_voltage} mV");
+
+            if stats.core_power_state != Some(0) {
+                label.push_str(" (Idle)");
+            }
+
+            main_label = Some(label);
+
+            for line in [
+                [
+                    (current_voltage as u32, y_spec.start),
+                    (current_voltage as u32, y_spec.end),
+                ],
+                [
+                    (x_spec.start, current_clock as u32),
+                    (x_spec.end, current_clock as u32),
+                ],
+            ] {
+                chart
+                    .draw_series(DashedLineSeries::new(
+                        line,
+                        8,
+                        5,
+                        ShapeStyle {
+                            color: colors.text.mix(0.5),
+                            filled: false,
+                            stroke_width: 1,
+                        },
+                    ))
+                    .unwrap();
+            }
+        }
+
+        let active_style = colors.text;
+        let hovered_style = colors.accent_bg;
+
+        let hovered_point = self
+            .dragging_point
+            .get()
+            .or_else(|| self.hovered_point.get());
+
+        let main_series = chart
+            .draw_series(PointSeries::of_element(
+                points.iter().map(vf_point_coords).enumerate(),
+                3,
+                ShapeStyle::from(&colors.success).filled(),
+                &|(i, coord), mut size, mut style| {
+                    let is_active = self.stats.borrow().voltage.gpu == Some(coord.0 as u64);
+                    if is_active {
+                        style.color = active_style.to_rgba();
+                        size = size * 3 / 2;
+                    }
+
+                    let mut negative_offset = false;
+                    let mut text_width = 160;
+
+                    let text = if hovered_point == Some(i) {
+                        let point = points[i];
+
+                        style.color = hovered_style.to_rgba();
+                        size *= 2;
+
+                        let mut text = format!("{} MHz", point.freq);
+
+                        let offset = point.freq as i32 - point.base_freq as i32;
+                        if offset != 0 {
+                            let symbol = if offset > 0 {
+                                "+"
+                            } else {
+                                negative_offset = true;
+                                ""
+                            };
+                            write!(text, " ({symbol}{offset}) MHz").unwrap();
+                            text_width += 50;
+                        }
+
+                        write!(text, " @ {} mV", point.voltage).unwrap();
+                        text
+                    } else {
+                        String::new()
+                    };
+
+                    let text_style = TextStyle {
+                        font: ("sans-serif", 15).into(),
+                        color: colors.text.to_backend_color(),
+                        pos: Pos::default(),
+                    };
+
+                    EmptyElement::at(coord)
+                        + Circle::new((0, 0), size, style)
+                        + Text::new(
+                            text,
+                            if negative_offset {
+                                (0, 15)
+                            } else {
+                                (-text_width, -15)
+                            },
+                            text_style,
+                        )
+                },
+            ))
+            .unwrap();
+
+        if let Some(label) = main_label {
+            main_series
+                .label(label)
+                .legend(move |(x, y)| Circle::new((x - 7, y), 5, active_style.filled()));
+        }
+
+        chart
+            .configure_series_labels()
+            .position(SeriesLabelPosition::UpperLeft)
+            .margin(20)
+            .legend_area_size(5)
+            .label_font(("sans-serif", 16, &colors.text))
+            .position(SeriesLabelPosition::UpperLeft)
+            .background_style(colors.background.mix(0.6))
+            .draw()
+            .unwrap();
+
+        let freq_range = chart.as_coord_spec().get_y_range();
+        let translate = chart.into_coord_trans();
+
+        let voltage_hover_margin =
+            ((max_point.voltage - min_point.voltage) as f32 * POINT_VOLTAGE_HOVER_MARGIN) as i32;
+        let freq_hover_margin =
+            ((max_point.freq - min_point.freq) as f32 * POINT_FREQ_HOVER_MARGIN) as i32;
+
+        let hovered_coords = self
+            .cursor_position
+            .get()
+            .and_then(|(x, y)| translate((x as i32, y as i32)));
+
+        let hovered_point = hovered_coords.and_then(|(voltage, freq)| {
+            points
+                .iter()
+                .enumerate()
+                .map(|(i, point)| {
+                    let voltage_distance = (voltage as i32 - point.voltage as i32).abs();
+                    let freq_distance = (freq as i32 - point.freq as i32).abs();
+                    (i, voltage_distance, freq_distance)
+                })
+                .filter(|(_, voltage_distance, freq_distance)| {
+                    *voltage_distance < voltage_hover_margin && *freq_distance < freq_hover_margin
+                })
+                .min_by(|lhs, rhs| lhs.1.cmp(&rhs.1).then_with(|| lhs.2.cmp(&rhs.2)))
+                .map(|(i, _, _)| i)
+        });
+        self.hovered_point.set(hovered_point);
+
+        if let Some((_voltage, freq)) = hovered_coords
+            && let Some(point_idx) = self.dragging_point.get()
+        {
+            points[point_idx].freq = freq.clamp(freq_range.start, freq_range.end);
+        }
+
+        root.present().unwrap();
+    }
+
+    pub fn get_configured_curve(&self) -> IndexMap<u8, config::CurvePoint> {
+        self.points
+            .borrow()
+            .iter()
+            .map(|point| {
+                let vf_point = config::CurvePoint {
+                    voltage: Some(point.voltage as i32),
+                    clockspeed: Some(point.freq as i32),
+                };
+                (point.index, vf_point)
+            })
+            .collect()
+    }
+}
+
+fn vf_point_coords(point: &NvidiaVfPoint) -> (u32, u32) {
+    (point.voltage, point.freq)
+}
+
+fn vf_point_base_coords(point: &NvidiaVfPoint) -> (u32, u32) {
+    (point.base_voltage, point.base_freq)
+}

--- a/lact-gui/src/app/pages/oc_page/vf_curve.rs
+++ b/lact-gui/src/app/pages/oc_page/vf_curve.rs
@@ -5,9 +5,9 @@ use crate::{
 use gtk::{
     gdk,
     prelude::{
-        BoxExt as _, ButtonExt as _, CheckButtonExt as _, DrawingAreaExtManual as _,
+        AdjustmentExt, BoxExt as _, ButtonExt as _, CheckButtonExt as _, DrawingAreaExtManual as _,
         EventControllerExt as _, GestureSingleExt as _, GtkWindowExt as _, OrientableExt as _,
-        PopoverExt, WidgetExt as _,
+        PopoverExt, RangeExt as _, ScaleExt as _, WidgetExt as _,
     },
 };
 use i18n_embed_fl::fl;
@@ -21,12 +21,12 @@ use plotters::{
 };
 use plotters_cairo::CairoBackend;
 use relm4::{ComponentParts, RelmObjectExt as _, RelmWidgetExt as _, binding::BoolBinding, css};
-use std::fmt::Write as _;
 use std::{
     cell::{Cell, RefCell},
     rc::Rc,
     sync::Arc,
 };
+use std::{cmp, fmt::Write as _};
 
 // In percentage
 const POINT_VOLTAGE_HOVER_MARGIN: f32 = 0.01;
@@ -38,6 +38,9 @@ pub struct VfCurveEditor {
     stats: Rc<RefCell<Arc<DeviceStats>>>,
     allow_editing: BoolBinding,
     locked_clocks_range: Rc<Cell<Option<(u32, u32)>>>,
+
+    visible_range_start: gtk::Adjustment,
+    visible_range_end: gtk::Adjustment,
 
     // Passed from app
     global_settings_changed: BoolBinding,
@@ -155,11 +158,38 @@ impl relm4::Component for VfCurveEditor {
 
                     gtk::Box {
                         set_orientation: gtk::Orientation::Horizontal,
-                        set_halign: gtk::Align::End,
                         set_spacing: 5,
+                        set_margin_horizontal: 5,
+
+                        gtk::Label {
+                            set_label: &fl!(I18N, "vf-curve-visible-range"),
+                            add_css_class: "heading",
+                        },
+
+                        gtk::Scale {
+                            set_adjustment: &model.visible_range_start,
+                            set_draw_value: true,
+                            set_width_request: 120,
+                            set_value_pos: gtk::PositionType::Right,
+                        },
+
+
+                        gtk::Label {
+                            set_label: &fl!(I18N, "vf-curve-visible-range-to"),
+                            add_css_class: "heading",
+                        },
+
+                        gtk::Scale {
+                            set_adjustment: &model.visible_range_end,
+                            set_draw_value: true,
+                            set_width_request: 120,
+                            set_value_pos: gtk::PositionType::Right,
+                        },
 
                         gtk::CheckButton {
                             set_label: Some(&fl!(I18N, "vf-curve-enable-editing")),
+                            set_halign: gtk::Align::End,
+                            set_hexpand: true,
                             add_css_class: "warning",
                             add_binding: (&model.allow_editing, "active"),
 
@@ -170,6 +200,7 @@ impl relm4::Component for VfCurveEditor {
 
                         gtk::Button {
                             set_label: &fl!(I18N, "reset-button"),
+                            set_halign: gtk::Align::End,
                             add_css_class: css::DESTRUCTIVE_ACTION,
 
                             #[watch]
@@ -188,6 +219,7 @@ impl relm4::Component for VfCurveEditor {
 
                         gtk::Button {
                             set_label: &fl!(I18N, "apply-button"),
+                            set_halign: gtk::Align::End,
                             add_binding: (&model.global_settings_changed, "sensitive"),
                             add_css_class: css::SUGGESTED_ACTION,
 
@@ -231,6 +263,8 @@ impl relm4::Component for VfCurveEditor {
             locked_clocks_range: Rc::default(),
             allow_editing: BoolBinding::new(false),
             cursor_position: Rc::new(Cell::new(None)),
+            visible_range_start: gtk::Adjustment::new(30.0, 0.0, 100.0, 1.0, 10.0, 0.0),
+            visible_range_end: gtk::Adjustment::new(100.0, 0.0, 100.0, 1.0, 10.0, 0.0),
             hovered_point: Rc::new(Cell::new(None)),
             dragging_point: Rc::new(Cell::new(None)),
             drag_modifiers: Rc::new(Cell::new(gdk::ModifierType::empty())),
@@ -287,10 +321,9 @@ impl relm4::Component for VfCurveEditor {
             }
             VfCurveEditorMsg::FlattenCurve => {
                 if let Some(base_point_idx) = self.hovered_point.get() {
+                    let (start, end) = self.visible_points_range();
                     let mut points = self.points.borrow_mut();
-                    // TODO
-                    let total_len = points.len();
-                    let points = &mut points[total_len / 3..];
+                    let points = &mut points[start..end];
 
                     let target_freq = points[base_point_idx].freq;
 
@@ -319,14 +352,15 @@ impl relm4::Component for VfCurveEditor {
 
 impl VfCurveEditor {
     fn draw_chart(&self, ctx: &cairo::Context, width: i32, height: i32, colors: PlotColorScheme) {
+        let (visible_start, visible_end) = self.visible_points_range();
+
         let mut points = self.points.borrow_mut();
+
+        let points = &mut points[visible_start..visible_end];
 
         if points.is_empty() {
             return;
         }
-
-        let total_len = points.len();
-        let points = &mut points[total_len / 3..];
 
         let backend = CairoBackend::new(ctx, (width as u32, height as u32)).unwrap();
 
@@ -590,6 +624,17 @@ impl VfCurveEditor {
         }
 
         root.present().unwrap();
+    }
+
+    fn visible_points_range(&self) -> (usize, usize) {
+        let len = self.points.borrow().len();
+        let start = (len as f64 * (self.visible_range_start.value() / 100.0)) as usize;
+        let start = cmp::min(start, len);
+
+        let end = (len as f64 * (self.visible_range_end.value() / 100.0)) as usize;
+        let end = cmp::min(end, len);
+
+        (cmp::min(start, end), cmp::max(end, start))
     }
 
     pub fn get_configured_curve(&self) -> IndexMap<u8, config::CurvePoint> {

--- a/lact-gui/src/app/pages/oc_page/vf_curve.rs
+++ b/lact-gui/src/app/pages/oc_page/vf_curve.rs
@@ -37,6 +37,7 @@ pub struct VfCurveEditor {
     points: Rc<RefCell<Vec<NvidiaVfPoint>>>,
     stats: Rc<RefCell<Arc<DeviceStats>>>,
     allow_editing: BoolBinding,
+    locked_clocks_range: Rc<Cell<Option<(u32, u32)>>>,
 
     // Passed from app
     global_settings_changed: BoolBinding,
@@ -227,6 +228,7 @@ impl relm4::Component for VfCurveEditor {
             points: Rc::default(),
             stats: Rc::default(),
             global_settings_changed,
+            locked_clocks_range: Rc::default(),
             allow_editing: BoolBinding::new(false),
             cursor_position: Rc::new(Cell::new(None)),
             hovered_point: Rc::new(Cell::new(None)),
@@ -253,9 +255,11 @@ impl relm4::Component for VfCurveEditor {
             VfCurveEditorMsg::Clocks(clocks_table) => {
                 let mut points = self.points.borrow_mut();
                 points.clear();
+                self.locked_clocks_range.take();
 
                 if let Some(ClocksTable::Nvidia(nvidia_table)) = clocks_table.as_deref() {
                     points.extend_from_slice(&nvidia_table.gpu_vf_curve);
+                    self.locked_clocks_range.set(nvidia_table.gpu_locked_clocks)
                 }
 
                 if points.is_empty() {
@@ -379,6 +383,32 @@ impl VfCurveEditor {
                 .legend(move |(x, y)| {
                     Rectangle::new([(x - 15, y + 2), (x, y - 1)], base_line_style.filled())
                 });
+        }
+
+        if let Some((min_freq, max_freq)) = self.locked_clocks_range.get() {
+            let mut curves = vec![(
+                [(x_spec.start, max_freq), (x_spec.end, max_freq)],
+                fl!(I18N, "max-gpu-clock"),
+                colors.error,
+            )];
+
+            if min_freq >= y_spec.start {
+                curves.push((
+                    [(x_spec.start, min_freq), (x_spec.end, min_freq)],
+                    fl!(I18N, "min-gpu-clock"),
+                    colors.warning,
+                ));
+            }
+
+            for (curve, label, color) in curves {
+                chart
+                    .draw_series(LineSeries::new(curve, &color))
+                    .unwrap()
+                    .label(label)
+                    .legend(move |(x, y)| {
+                        Rectangle::new([(x - 15, y + 2), (x, y - 1)], color.filled())
+                    });
+            }
         }
 
         let mut main_label = None;

--- a/lact-schema/src/config.rs
+++ b/lact-schema/src/config.rs
@@ -87,6 +87,52 @@ pub struct ClocksConfiguration {
     pub voltage_offset: Option<i32>,
 }
 
+impl ClocksConfiguration {
+    pub fn apply_clocks_command(&mut self, command: &SetClocksCommand) {
+        let value = command.value;
+        match command.r#type {
+            ClockspeedType::MaxCoreClock => self.max_core_clock = value,
+            ClockspeedType::MaxMemoryClock => self.max_memory_clock = value,
+            ClockspeedType::MaxVoltage => self.max_voltage = value,
+            ClockspeedType::MinCoreClock => self.min_core_clock = value,
+            ClockspeedType::MinMemoryClock => self.min_memory_clock = value,
+            ClockspeedType::MinVoltage => self.min_voltage = value,
+            ClockspeedType::VoltageOffset => self.voltage_offset = value,
+            ClockspeedType::GpuClockOffset(pstate) => match value {
+                Some(value) => {
+                    self.gpu_clock_offsets.insert(pstate, value);
+                }
+                None => {
+                    self.gpu_clock_offsets.shift_remove(&pstate);
+                }
+            },
+            ClockspeedType::MemClockOffset(pstate) => match value {
+                Some(value) => {
+                    self.mem_clock_offsets.insert(pstate, value);
+                }
+                None => {
+                    self.mem_clock_offsets.shift_remove(&pstate);
+                }
+            },
+            ClockspeedType::GpuVfCurveClock(point) => {
+                self.gpu_vf_curve.entry(point).or_default().clockspeed = value;
+            }
+            ClockspeedType::GpuVfCurveVoltage(point) => {
+                self.gpu_vf_curve.entry(point).or_default().voltage = value;
+            }
+            ClockspeedType::MemVfCurveClock(point) => {
+                self.mem_vf_curve.entry(point).or_default().clockspeed = value;
+            }
+            ClockspeedType::MemVfCurveVoltage(point) => {
+                self.mem_vf_curve.entry(point).or_default().voltage = value;
+            }
+            ClockspeedType::Reset => {
+                *self = ClocksConfiguration::default();
+            }
+        }
+    }
+}
+
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct CurvePoint {
@@ -128,52 +174,6 @@ mod int_map {
 impl GpuConfig {
     pub fn is_core_clocks_used(&self) -> bool {
         self.clocks_configuration != ClocksConfiguration::default()
-    }
-
-    pub fn apply_clocks_command(&mut self, command: &SetClocksCommand) {
-        let clocks = &mut self.clocks_configuration;
-        let value = command.value;
-        match command.r#type {
-            ClockspeedType::MaxCoreClock => clocks.max_core_clock = value,
-            ClockspeedType::MaxMemoryClock => clocks.max_memory_clock = value,
-            ClockspeedType::MaxVoltage => clocks.max_voltage = value,
-            ClockspeedType::MinCoreClock => clocks.min_core_clock = value,
-            ClockspeedType::MinMemoryClock => clocks.min_memory_clock = value,
-            ClockspeedType::MinVoltage => clocks.min_voltage = value,
-            ClockspeedType::VoltageOffset => clocks.voltage_offset = value,
-            ClockspeedType::GpuClockOffset(pstate) => match value {
-                Some(value) => {
-                    clocks.gpu_clock_offsets.insert(pstate, value);
-                }
-                None => {
-                    clocks.gpu_clock_offsets.shift_remove(&pstate);
-                }
-            },
-            ClockspeedType::MemClockOffset(pstate) => match value {
-                Some(value) => {
-                    clocks.mem_clock_offsets.insert(pstate, value);
-                }
-                None => {
-                    clocks.mem_clock_offsets.shift_remove(&pstate);
-                }
-            },
-            ClockspeedType::GpuVfCurveClock(point) => {
-                clocks.gpu_vf_curve.entry(point).or_default().clockspeed = value;
-            }
-            ClockspeedType::GpuVfCurveVoltage(point) => {
-                clocks.gpu_vf_curve.entry(point).or_default().voltage = value;
-            }
-            ClockspeedType::MemVfCurveClock(point) => {
-                clocks.mem_vf_curve.entry(point).or_default().clockspeed = value;
-            }
-            ClockspeedType::MemVfCurveVoltage(point) => {
-                clocks.mem_vf_curve.entry(point).or_default().voltage = value;
-            }
-            ClockspeedType::Reset => {
-                *clocks = ClocksConfiguration::default();
-                assert!(!self.is_core_clocks_used());
-            }
-        }
     }
 }
 

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -441,6 +441,17 @@ pub struct NvidiaClocksTable {
     pub gpu_clock_range: Option<(u32, u32)>,
     #[serde(default)]
     pub vram_clock_range: Option<(u32, u32)>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub gpu_vf_curve: Vec<NvidiaVfPoint>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Copy)]
+pub struct NvidiaVfPoint {
+    pub index: u8,
+    pub freq: u32,
+    pub voltage: u32,
+    pub base_freq: u32,
+    pub base_voltage: u32,
 }
 
 /// Doc from `xe_gt_freq.c`


### PR DESCRIPTION
Closes #936 

This PR adds a VF curve editor, based on some undocumented NvAPI queries. There are no guarantees about its safety, stability across driver versions, etc. But it might still be useful for some people who might want to tweak this at their own risk.
With this editor, you can do undervolts in a very similar way to MSI Afterburner on Windows, by bumping a desired voltage point to the desired clockspeed, and flattening the curve to the right:

Special thanks to @Ristovski for helping with the reverse engineering efforts

<img width="1091" height="691" alt="image" src="https://github.com/user-attachments/assets/5b08210d-07ce-4c12-a3a6-54d6f05f66b0" />
