### PR TITLE
fix: small sidebar grooming

### DIFF
--- a/lact-gui/src/app.css
+++ b/lact-gui/src/app.css
@@ -2,3 +2,11 @@
 .app {
 
 }
+
+.main-sidebar-container .sidebar {
+    border-right-width: 0;
+}
+
+.main-sidebar-container separator {
+    margin: 0 2px;
+}

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -166,6 +166,7 @@ impl AsyncComponent for AppModel {
                                 set_content = &gtk::Box {
                                     set_orientation: gtk::Orientation::Vertical,
                                     set_vexpand: true,
+                                    add_css_class: "main-sidebar-container",
 
                                     gtk::Box {
                                         set_orientation: gtk::Orientation::Vertical,


### PR DESCRIPTION
before:
<img width="210" height="760" alt="image" src="https://github.com/user-attachments/assets/6a344f76-7660-4401-9518-3e4d62fa711f" />
there is a border around sidebar component (inside sidebar itself) + separators intersect with the natural borders 
after
<img width="210" height="760" alt="image" src="https://github.com/user-attachments/assets/01c3e7de-1c30-4530-ba59-5fcfc4438df6" />
