### PR TITLE
fix: remove scale decimals in vf curve

### DIFF
--- a/lact-gui/src/app/pages/oc_page/vf_curve.rs
+++ b/lact-gui/src/app/pages/oc_page/vf_curve.rs
@@ -169,8 +169,9 @@ impl relm4::Component for VfCurveEditor {
                         gtk::Scale {
                             set_adjustment: &model.visible_range_start,
                             set_draw_value: true,
-                            set_width_request: 120,
+                            set_width_request: 150,
                             set_value_pos: gtk::PositionType::Right,
+                            set_digits: 0,
                         },
 
 
@@ -182,8 +183,9 @@ impl relm4::Component for VfCurveEditor {
                         gtk::Scale {
                             set_adjustment: &model.visible_range_end,
                             set_draw_value: true,
-                            set_width_request: 120,
+                            set_width_request: 150,
                             set_value_pos: gtk::PositionType::Right,
+                            set_digits: 0,
                         },
 
                         gtk::CheckButton {


### PR DESCRIPTION
new UI looks great. The right click in edit mod is not that obvious, but much better than keybind in afterburner.

I suggest a small change
<img width="562" height="99" alt="image" src="https://github.com/user-attachments/assets/06f66285-6416-4b41-b844-98c6d7b0ce20" />
