### PR TITLE
feat: sync selected page title into content's Toolbox header

### DIFF
--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -1,5 +1,5 @@
 info-page = Information 
-oc-page = OC 
+oc-page = Overclock
 thermals-page = Thermals 
 software-page = Software 
 

--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -1,7 +1,7 @@
-info-page = Information 
-oc-page = Overclock
+info-page = Hardware Info
+oc-page = Overclocking
 thermals-page = Thermals 
-software-page = Software 
+software-page = Software Info
 
 hardware-info = Hardware Information
 

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -239,13 +239,12 @@ impl AsyncComponent for AppModel {
                         },
 
                         #[wrap(Some)]
+                        #[name = "content_page"]
                         set_content = &adw::NavigationPage {
-                            set_title: "LACT",
 
                             #[wrap(Some)]
                             set_child = &adw::ToolbarView {
                                 add_top_bar = &adw::HeaderBar {
-                                    set_show_title: false,
 
                                     pack_end = &gtk::MenuButton {
                                         set_icon_name: "open-menu-symbolic",
@@ -412,9 +411,12 @@ impl AsyncComponent for AppModel {
                                             add_named[Some("crash_page")] = model.crash_page.widget(),
 
                                             set_visible_child_name: &CONFIG.read().selected_tab,
-                                            connect_visible_child_name_notify => move |stack| {
-                                                if let Some(name) = stack.visible_child_name() {
-                                                    let name = name.to_string();
+                                            connect_visible_child_name_notify[content_page] => move |stack| {
+                                                if let Some(child) = stack.visible_child() {
+                                                    let page = stack.page(&child);
+                                                    content_page.set_title(&page.title().unwrap_or_default());
+
+                                                    let name = stack.visible_child_name().unwrap().to_string();
                                                     if name != "crash_page" {
                                                         CONFIG.write().edit(|config| {
                                                             config.selected_tab = name;
@@ -574,6 +576,11 @@ impl AsyncComponent for AppModel {
         };
 
         let widgets = view_output!();
+
+        if let Some(child) = widgets.root_stack.visible_child() {
+            let page = widgets.root_stack.page(&child);
+            widgets.content_page.set_title(&page.title().unwrap_or_default());
+        }
 
         if let Some(err) = conn_err {
             show_embedded_info(&root, err);

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -579,7 +579,9 @@ impl AsyncComponent for AppModel {
 
         if let Some(child) = widgets.root_stack.visible_child() {
             let page = widgets.root_stack.page(&child);
-            widgets.content_page.set_title(&page.title().unwrap_or_default());
+            widgets
+                .content_page
+                .set_title(&page.title().unwrap_or_default());
         }
 
         if let Some(err) = conn_err {

--- a/lact-gui/src/app/pages/info_page.rs
+++ b/lact-gui/src/app/pages/info_page.rs
@@ -34,7 +34,7 @@ impl relm4::SimpleComponent for InformationPage {
             set_margin_vertical: 15,
             set_margin_horizontal: 30,
 
-            PageSection::new(&fl!(I18N, "hardware-info")) {
+            PageSection::new("") {
                 append_child = &model.values_list.widget().clone() -> gtk::FlowBox {
                     set_orientation: gtk::Orientation::Horizontal,
                     set_column_spacing: 10,


### PR DESCRIPTION
<img width="1046" height="274" alt="image" src="https://github.com/user-attachments/assets/354af04f-d6c8-41e7-97e6-aafd08035ea0" />
should we rename information to hardware info to make it less generic?
<img width="1046" height="274" alt="image" src="https://github.com/user-attachments/assets/461899e1-a475-4c8f-bdb5-fe16e5f882b9" />
