### PR TITLE
feat: use adwBanner to show enable AMD OC message

### DIFF
--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -69,9 +69,7 @@ automatic-mode-threshold-tooltip = Switch fan control to auto mode when the temp
     This option allows to work around this limitation by only using the custom curve when above a specific temperature, with the card's builtin auto mode that supports zero RPM being used below it.
 
 amd-oc = AMD Overclocking
-amd-oc-disabled = 
-    AMD Overclocking support is not enabled!
-    You can still change basic settings, but the more advanced clocks and voltage control will not be available.
+amd-oc-disabled = AMD Overclocking is not enabled! Some functionality unavailable
 amd-oc-status = AMD Overclocking is currently: <b>{$status ->
     [true] Enabled
     [false] Disabled

--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -69,7 +69,7 @@ automatic-mode-threshold-tooltip = Switch fan control to auto mode when the temp
     This option allows to work around this limitation by only using the custom curve when above a specific temperature, with the card's builtin auto mode that supports zero RPM being used below it.
 
 amd-oc = AMD Overclocking
-amd-oc-disabled = AMD Overclocking is not enabled! <a href="https://github.com/ilya-zlobintsev/LACT/wiki/Overclocking-(AMD)">Some functionality unavailable</a>
+amd-oc-disabled = AMD Overclocking is not enabled! <a href="https://github.com/ilya-zlobintsev/LACT/wiki/Overclocking-(AMD)">Some functionality will not be available.</a>
 amd-oc-status = AMD Overclocking is currently: <b>{$status ->
     [true] Enabled
     [false] Disabled

--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -69,7 +69,7 @@ automatic-mode-threshold-tooltip = Switch fan control to auto mode when the temp
     This option allows to work around this limitation by only using the custom curve when above a specific temperature, with the card's builtin auto mode that supports zero RPM being used below it.
 
 amd-oc = AMD Overclocking
-amd-oc-disabled = AMD Overclocking is not enabled! Some functionality unavailable
+amd-oc-disabled = AMD Overclocking is not enabled! <a href="https://github.com/ilya-zlobintsev/LACT/wiki/Overclocking-(AMD)">Some functionality unavailable</a>
 amd-oc-status = AMD Overclocking is currently: <b>{$status ->
     [true] Enabled
     [false] Disabled

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -392,9 +392,9 @@ impl AsyncComponent for AppModel {
 
                                 add_top_bar = &adw::Banner {
                                     #[watch]
-                                    set_revealed: true,
-                                    // set_revealed: model.system_info.amdgpu_overdrive_enabled == Some(false),
+                                    set_revealed: model.system_info.amdgpu_overdrive_enabled == Some(false),
                                     set_title: &fl!(I18N, "amd-oc-disabled"),
+                                    set_use_markup: true,
                                     set_button_label: Some(&fl!(I18N, "enable-amd-oc")),
 
                                     connect_button_clicked => AppMsg::ShowOverdriveDialog,

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -390,6 +390,16 @@ impl AsyncComponent for AppModel {
                                     }
                                 },
 
+                                add_top_bar = &adw::Banner {
+                                    #[watch]
+                                    set_revealed: true,
+                                    // set_revealed: model.system_info.amdgpu_overdrive_enabled == Some(false),
+                                    set_title: &fl!(I18N, "amd-oc-disabled"),
+                                    set_button_label: Some(&fl!(I18N, "enable-amd-oc")),
+
+                                    connect_button_clicked => AppMsg::ShowOverdriveDialog,
+                                },
+
                                 #[wrap(Some)]
                                 set_content = &adw::Clamp {
                                     set_maximum_size: CONTENT_MAXIMUM_WIDTH,
@@ -519,9 +529,9 @@ impl AsyncComponent for AppModel {
         let info_page = InformationPage::detach_default();
 
         let oc_page = OcPage::builder()
-            .launch((system_info.clone(), settings_changed.clone()))
+            .launch(settings_changed.clone())
             .forward(sender.input_sender(), |msg| msg);
-        let thermals_page = ThermalsPage::builder().launch(system_info.clone()).detach();
+        let thermals_page = ThermalsPage::builder().launch(()).detach();
 
         let software_page = SoftwarePage::builder()
             .launch((system_info.clone(), daemon_client.embedded))

--- a/lact-gui/src/app/pages/oc_page.rs
+++ b/lact-gui/src/app/pages/oc_page.rs
@@ -8,23 +8,16 @@ mod vf_curve;
 use super::PageUpdate;
 use crate::app::pages::oc_page::gpu_stats_section::GpuStatsSectionMsg;
 use crate::app::pages::oc_page::vf_curve::{VfCurveEditor, VfCurveEditorMsg};
-use crate::{
-    I18N,
-    app::{ext::RelmDefaultLauchable, msg::AppMsg},
-};
+use crate::app::{ext::RelmDefaultLauchable, msg::AppMsg};
 use amdgpu_sysfs::gpu_handle::{
     PerformanceLevel, PowerLevelKind, power_profile_mode::PowerProfileModesTable,
 };
 use clocks_frame::{ClocksFrame, ClocksFrameMsg};
 use gpu_stats_section::GpuStatsSection;
-use gtk::{
-    pango,
-    prelude::{BoxExt, ButtonExt, FrameExt, OrientableExt, WidgetExt},
-};
-use i18n_embed_fl::fl;
+use gtk::prelude::{BoxExt, OrientableExt, WidgetExt};
 use indexmap::IndexMap;
 use lact_schema::config;
-use lact_schema::{ClocksTable, DeviceInfo, PowerStates, SystemInfo};
+use lact_schema::{ClocksTable, DeviceInfo, PowerStates};
 use performance_frame::{PerformanceFrame, PerformanceFrameMsg};
 use power_cap_section::{PowerCapMsg, PowerCapSection};
 use power_states::power_states_frame::{PowerStatesFrame, PowerStatesFrameMsg};
@@ -35,7 +28,6 @@ use tracing::debug;
 
 pub struct OcPage {
     stats_section: relm4::Controller<GpuStatsSection>,
-    system_info: SystemInfo,
     device_info: Option<Arc<DeviceInfo>>,
 
     performance_frame: relm4::Controller<PerformanceFrame>,
@@ -64,7 +56,7 @@ pub enum OcPageMsg {
 
 #[relm4::component(pub)]
 impl relm4::Component for OcPage {
-    type Init = (SystemInfo, BoolBinding);
+    type Init = BoolBinding;
     type Input = OcPageMsg;
     type Output = AppMsg;
     type CommandOutput = ();
@@ -77,33 +69,6 @@ impl relm4::Component for OcPage {
             set_margin_top: 15,
             set_margin_bottom: 60,
 
-            gtk::Frame {
-                #[watch]
-                set_visible: model.system_info.amdgpu_overdrive_enabled == Some(false) && model.device_info.as_ref().is_some_and(|info| info.driver == "amdgpu"),
-                set_label_align: 0.3,
-
-                gtk::Box {
-                    set_orientation: gtk::Orientation::Vertical,
-                    set_spacing: 2,
-                    set_margin_all: 10,
-
-                    gtk::Label {
-                        set_markup: &fl!(I18N, "amd-oc-disabled"),
-                        set_wrap: true,
-                        set_wrap_mode: pango::WrapMode::Word,
-                    },
-
-                    gtk::Button {
-                        set_label: &fl!(I18N, "enable-amd-oc"),
-                        set_halign: gtk::Align::End,
-
-                        connect_clicked[sender] => move |_| {
-                            sender.output(AppMsg::ShowOverdriveDialog).expect("Channel closed");
-                        }
-                    },
-                },
-            },
-
             model.stats_section.widget(),
             model.power_cap_section.widget(),
             model.performance_frame.widget(),
@@ -113,7 +78,7 @@ impl relm4::Component for OcPage {
     }
 
     fn init(
-        (system_info, settings_changed): Self::Init,
+        settings_changed: Self::Init,
         root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
@@ -129,7 +94,6 @@ impl relm4::Component for OcPage {
         let model = Self {
             stats_section,
             device_info: None,
-            system_info,
             performance_frame,
             power_cap_section,
             power_states_frame,

--- a/lact-gui/src/app/pages/thermals_page.rs
+++ b/lact-gui/src/app/pages/thermals_page.rs
@@ -25,7 +25,7 @@ use gtk::{
 };
 use i18n_embed_fl::fl;
 use lact_schema::{
-    DeviceFlag, FanControlMode, SystemInfo,
+    DeviceFlag, FanControlMode,
     config::{FanControlSettings, FanCurve, GpuConfig},
     default_fan_curve,
 };
@@ -41,7 +41,6 @@ const STATIC_PAGE: &str = "static";
 
 pub struct ThermalsPage {
     fan_curve_frame: relm4::Controller<FanCurveFrame>,
-    system_info: SystemInfo,
     selected_mode: StringBinding,
 
     custom_control_supported: bool,
@@ -91,7 +90,7 @@ pub enum ThermalsPageMsg {
 
 #[relm4::component(pub)]
 impl relm4::Component for ThermalsPage {
-    type Init = SystemInfo;
+    type Init = ();
     type Input = ThermalsPageMsg;
     type Output = ();
     type CommandOutput = ();
@@ -102,17 +101,6 @@ impl relm4::Component for ThermalsPage {
             set_spacing: 15,
             set_margin_vertical: 15,
             set_margin_horizontal: 30,
-
-            gtk::Frame {
-                #[watch]
-                set_visible: model.system_info.amdgpu_overdrive_enabled == Some(false)
-                    && model.has_pmfw
-                    && model.fan_speed.is_some(),
-
-                gtk::Label {
-                    set_label: &fl!(I18N, "oc-missing-fan-control-warning"),
-                },
-            },
 
             PageSection::new(&fl!(I18N, "monitoring-section")) {
                 append_child = &gtk::FlowBox {
@@ -351,7 +339,7 @@ impl relm4::Component for ThermalsPage {
     }
 
     fn init(
-        system_info: Self::Init,
+        _init: Self::Init,
         root: Self::Root,
         _sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
@@ -387,7 +375,6 @@ impl relm4::Component for ThermalsPage {
             fan_curve_frame,
             throttling: String::new(),
             temperatures: None,
-            system_info,
             pmfw_options,
             pmfw_change_signals,
             custom_control_supported: false,


### PR DESCRIPTION
on one of the screenshots you shared I noticed that the current style for Enable AMD OC doesn't fit. 

I tried to use PageSection first, but it didn't look right. Also We want this warning to be shown all the time, because it's relevant to multiple pages.

<img width="1073" height="271" alt="image" src="https://github.com/user-attachments/assets/11784d4c-0204-48b6-9e4e-af3a579a513f" />
<img width="1073" height="271" alt="image" src="https://github.com/user-attachments/assets/3526db83-e33b-4432-8a24-c9cd29fbd80b" />
