### PR TITLE
feat: add 12VHPWR/12V-2x6 power connector monitoring via I2C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1396,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "i2cdev"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b940f7497c4f95b863b21cd34c3737b53a67d80d94cf29055d7f7eeca6ffdb4"
+dependencies = [
+ "bitflags 2.11.1",
+ "byteorder",
+ "libc",
+ "nix 0.26.4",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1726,7 @@ dependencies = [
  "divan",
  "easy_fuser",
  "futures",
+ "i2cdev",
  "indexmap",
  "insta",
  "jiff",
@@ -1985,6 +2004,17 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/lact-daemon/Cargo.toml
+++ b/lact-daemon/Cargo.toml
@@ -48,6 +48,7 @@ libcopes = "1.0.0"
 libloading = "0.8.9" # Can be updated when https://github.com/rust-lang/rust-bindgen/issues/3332 is released
 
 ureq = { version = "3.3.0", features = ["json", "rustls"] }
+i2cdev = "0.6.2"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/lact-daemon/src/config.rs
+++ b/lact-daemon/src/config.rs
@@ -1,7 +1,7 @@
 use crate::server::gpu_controller::{GpuController, VENDOR_NVIDIA};
 use anyhow::Context;
 use indexmap::IndexMap;
-use lact_schema::config::{GpuConfig, Profile, ProfileHooks};
+use lact_schema::config::{GpuConfig, PowerConnectorConfig, Profile, ProfileHooks};
 use nix::unistd::{Group, getuid};
 use notify::{RecommendedWatcher, Watcher};
 use serde::{Deserialize, Serialize};
@@ -553,3 +553,5 @@ mod tests {
         );
     }
 }
+
+// PowerConnectorConfig moved to lact-schema

--- a/lact-daemon/src/server/gpu_controller.rs
+++ b/lact-daemon/src/server/gpu_controller.rs
@@ -3,7 +3,7 @@ mod amd;
 pub mod common;
 mod intel;
 #[cfg(feature = "nvidia")]
-mod nvidia;
+pub mod nvidia;
 
 use amd::AmdGpuController;
 use intel::IntelGpuController;
@@ -39,6 +39,7 @@ pub type DynGpuController = Box<dyn GpuController>;
 type FanControlHandle = (Rc<Notify>, JoinHandle<()>);
 
 pub trait GpuController {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
     fn controller_info(&self) -> &CommonControllerInfo;
 
     fn device_type(&self) -> DeviceType;

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -718,6 +718,10 @@ impl AmdGpuController {
 }
 
 impl GpuController for AmdGpuController {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn controller_info(&self) -> &CommonControllerInfo {
         &self.common
     }
@@ -1032,6 +1036,7 @@ impl GpuController for AmdGpuController {
                 .ok()
                 .and_then(|levels| levels.active),
             throttle_info,
+            power_connector: None,
         }
     }
 

--- a/lact-daemon/src/server/gpu_controller/intel.rs
+++ b/lact-daemon/src/server/gpu_controller/intel.rs
@@ -576,6 +576,10 @@ impl IntelGpuController {
 }
 
 impl GpuController for IntelGpuController {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn controller_info(&self) -> &CommonControllerInfo {
         &self.common
     }

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -19,6 +19,10 @@ use amdgpu_sysfs::{
     hw_mon::Temperature,
 };
 use anyhow::{Context, anyhow, bail};
+use i2cdev::core::I2CDevice;
+use i2cdev::linux::LinuxI2CDevice;
+use lact_schema::PowerConnectorStats;
+use lact_schema::ConnectorPinStats;
 use driver::DriverHandle;
 use futures::{FutureExt, future::LocalBoxFuture, join};
 use indexmap::IndexMap;
@@ -72,6 +76,9 @@ pub struct NvidiaGpuController {
     last_applied_vram_locked_clocks: RefCell<Option<(u32, u32)>>,
     // Check if reset is needed to avoid unnecessarily going to nvapi
     vf_curve_written: Cell<bool>,
+    pub power_connector_i2c_bus: Option<u8>,
+    pub power_connector_i2c_addr: u8,
+    pub power_connector_reg_base: u8,
 }
 
 impl NvidiaGpuController {
@@ -146,6 +153,9 @@ impl NvidiaGpuController {
             last_applied_gpu_locked_clocks: RefCell::new(None),
             last_applied_vram_locked_clocks: RefCell::new(None),
             vf_curve_written: Cell::new(false),
+            power_connector_i2c_bus: None,
+            power_connector_i2c_addr: 0x2b,
+            power_connector_reg_base: 0x80,
         })
     }
 
@@ -518,7 +528,37 @@ fn point_count_from_mask(mask: [u32; 8]) -> usize {
     count
 }
 
+impl NvidiaGpuController {
+    pub fn set_power_connector_config(&mut self, bus: u8, addr: u8, reg_base: u8) {
+        self.power_connector_i2c_bus = Some(bus);
+        self.power_connector_i2c_addr = addr;
+        self.power_connector_reg_base = reg_base;
+    }
+
+    fn read_power_connector(i2c_bus: u8, i2c_addr: u8, reg_base: u8) -> Option<PowerConnectorStats> {
+        let path = format!("/dev/i2c-{}", i2c_bus);
+        let mut dev = LinuxI2CDevice::new(&path, u16::from(i2c_addr)).ok()?;
+        let mut pins = Vec::new();
+        for i in 0..6u8 {
+            let offset = reg_base + i * 4;
+            let v_hi = dev.smbus_read_byte_data(offset).ok()? as u32;
+            let v_lo = dev.smbus_read_byte_data(offset + 1).ok()? as u32;
+            let c_hi = dev.smbus_read_byte_data(offset + 2).ok()? as u32;
+            let c_lo = dev.smbus_read_byte_data(offset + 3).ok()? as u32;
+            pins.push(ConnectorPinStats {
+                voltage_mv: (v_hi << 8) | v_lo,
+                current_ma: (c_hi << 8) | c_lo,
+            });
+        }
+        Some(PowerConnectorStats { pins })
+    }
+}
+
 impl GpuController for NvidiaGpuController {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn controller_info(&self) -> &CommonControllerInfo {
         &self.common
     }
@@ -641,6 +681,7 @@ impl GpuController for NvidiaGpuController {
         clippy::cast_sign_loss,
         clippy::too_many_lines
     )]
+
     fn get_stats(&self, gpu_config: Option<&GpuConfig>) -> DeviceStats {
         let device = self.device();
 
@@ -838,6 +879,9 @@ impl GpuController for NvidiaGpuController {
             core_power_state: active_pstate,
             memory_power_state: active_pstate,
             pcie_power_state: None,
+            power_connector: self.power_connector_i2c_bus.and_then(|bus| {
+                Self::read_power_connector(bus, self.power_connector_i2c_addr, self.power_connector_reg_base)
+            }),
         }
     }
 

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "nvidia")]
+use super::gpu_controller::nvidia::NvidiaGpuController;
 use super::{
     gpu_controller::{DynGpuController, GpuController, common::fan_control::FanCurveExt},
     profiles::ProfileWatcherCommand,
@@ -133,6 +135,24 @@ impl<'a> Handler {
         }
         info!("initialized {} GPUs", controllers.len());
 
+        // Apply per-GPU power connector config
+        #[cfg(feature = "nvidia")]
+        {
+            if let Ok(gpus) = config.gpus() {
+                for (gpu_id, controller) in controllers.iter_mut() {
+                    if let Some(gpu_config) = gpus.get(gpu_id) {
+                        if let Some(pc) = &gpu_config.power_connector {
+                            if let Some(nvidia) = controller.as_any_mut().downcast_mut::<NvidiaGpuController>() {
+                                nvidia.set_power_connector_config(pc.i2c_bus, pc.i2c_addr, pc.reg_base);
+                            }
+                        }
+                    }
+                }
+            } else {
+                error!("Could not read GPU config for power connector setup");
+            }
+        }
+
         match fs::read_to_string("/proc/cmdline") {
             Ok(cmdline) => {
                 if cmdline
@@ -226,6 +246,21 @@ impl<'a> Handler {
                 }
 
                 *controllers_guard = new_controllers;
+                // Apply per-GPU power connector config
+                #[cfg(feature = "nvidia")]
+                {
+                    if let Ok(gpus) = config.gpus() {
+                        for (gpu_id, controller) in controllers_guard.iter_mut() {
+                            if let Some(gpu_config) = gpus.get(gpu_id) {
+                                if let Some(pc) = &gpu_config.power_connector {
+                                    if let Some(nvidia) = controller.as_any_mut().downcast_mut::<NvidiaGpuController>() {
+                                        nvidia.set_power_connector_config(pc.i2c_bus, pc.i2c_addr, pc.reg_base);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
                 match apply_config_to_controllers(&controllers_guard, &config).await {
                     Ok(()) => {
@@ -1179,7 +1214,7 @@ fn load_controllers(
             let device_path = entry.path().join("device");
 
             match init_controller(device_path.clone(), pci_db) {
-                Ok(controller) => {
+                Ok(mut controller) => {
                     let info = controller.controller_info();
                     let id = info.build_id();
 
@@ -1188,6 +1223,7 @@ fn load_controllers(
                         info.driver,
                         info.sysfs_path.display()
                     );
+
 
                     controllers.insert(id, controller);
                 }

--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -268,3 +268,17 @@ about = About
 # Crash page
 crash-page-title = Application Crashed
 exit = Exit
+
+# 12V-2x6 Power Connector
+connector-section-title = 12V-2x6 Connector
+connector-total-current = Total Current
+connector-total-power = Total Power
+connector-pin = Pin { $n }
+connector-alarm-group = 12V-2x6 Connector Alarm
+connector-alarm-threshold = Pin current threshold (A)
+connector-alarm-threshold-subtitle = Alarm triggers when any pin exceeds this value
+connector-alarm-notify = Show notification
+connector-alarm-command = Run command on alarm
+connector-alarm-command-subtitle = Leave empty to disable
+connector-alarm-message = ⚠️ 12V-2x6 connector alarm!\nPin current { $current }A exceeds threshold { $threshold }A
+connector-alarm-command-placeholder = e.g. systemctl poweroff

--- a/lact-gui/i18n/it/lact_gui.ftl
+++ b/lact-gui/i18n/it/lact_gui.ftl
@@ -235,3 +235,17 @@ hw-ip-info = Informazioni IP Hardware
 hw-queues = Code
 theme = tema
 theme-auto = Automatico
+
+# Connettore di alimentazione 12V-2x6
+connector-section-title = Connettore 12V-2x6
+connector-total-current = Corrente Totale
+connector-total-power = Potenza Totale
+connector-pin = Pin { $n }
+connector-alarm-group = Allarme Connettore 12V-2x6
+connector-alarm-threshold = Soglia corrente per pin (A)
+connector-alarm-threshold-subtitle = L'allarme scatta quando un pin supera questo valore
+connector-alarm-notify = Mostra notifica
+connector-alarm-command = Esegui comando all'allarme
+connector-alarm-command-subtitle = Lascia vuoto per disabilitare
+connector-alarm-message = ⚠️ Allarme connettore 12V-2x6!\nCorrente pin { $current }A supera la soglia { $threshold }A
+connector-alarm-command-placeholder = es. systemctl poweroff

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -687,6 +687,42 @@ impl AppModel {
                 }
             }
             AppMsg::Stats(stats) => {
+                // Check connector alarm
+                if let Some(connector) = &stats.power_connector {
+                    if let Some(alarm) = CONFIG.read().connector_alarm.clone() {
+                        let max_pin_current = connector.pins.iter()
+                            .map(|p| p.current_a())
+                            .fold(f64::NAN, f64::max);
+                        if max_pin_current > alarm.pin_current_threshold_a {
+                            if alarm.notify {
+                                let msg = fl!(
+                                    I18N,
+                                    "connector-alarm-message",
+                                    current = format!("{:.3}", max_pin_current),
+                                    threshold = format!("{:.1}", alarm.pin_current_threshold_a)
+                                );
+                                relm4::spawn_local(async move {
+                                    let _ = tokio::process::Command::new("pw-play")
+                                        .arg("/usr/share/sounds/freedesktop/stereo/dialog-warning.oga")
+                                        .spawn();
+                                });
+                                show_error(root, &anyhow::anyhow!("{}", msg));
+                            }
+                            if let Some(cmd) = &alarm.command {
+                                if !cmd.is_empty() {
+                                    let cmd = cmd.clone();
+                                    relm4::spawn_local(async move {
+                                        let _ = tokio::process::Command::new("sh")
+                                            .arg("-c")
+                                            .arg(&cmd)
+                                            .spawn();
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+
                 let update = PageUpdate::Stats(stats.clone());
                 self.oc_page.emit(OcPageMsg::Update {
                     update: update.clone(),

--- a/lact-gui/src/app/graphs_window/mod.rs
+++ b/lact-gui/src/app/graphs_window/mod.rs
@@ -27,6 +27,7 @@ use std::{
 };
 
 pub struct GraphsWindow {
+    has_connector: bool,
     time_period_seconds_adj: gtk::Adjustment,
     gpu_id: Option<String>,
     edit_mode: BoolBinding,
@@ -53,6 +54,7 @@ pub enum GraphsWindowMsg {
     SaveConfig,
     Show,
     ExportData,
+    AddConnectorPlot,
 }
 
 #[relm4::component(pub)]
@@ -118,7 +120,7 @@ impl relm4::Component for GraphsWindow {
                         set_label: &fl!(I18N, "reset-button"),
                         set_tooltip: &fl!(I18N, "reset-all-graphs-tooltip"),
                         add_css_class: "destructive-action",
-                        connect_clicked => GraphsWindowMsg::SetConfig(default_plots()),
+                        connect_clicked => GraphsWindowMsg::SetConfig(default_plots(false)),
                     },
 
                     gtk::Button {
@@ -176,6 +178,7 @@ impl relm4::Component for GraphsWindow {
             edit_mode,
             plots,
             gpu_id: None,
+            has_connector: false,
             vram_clock_ratio: 1.0,
             stats_data,
         };
@@ -204,6 +207,10 @@ impl relm4::Component for GraphsWindow {
                 stats,
                 selected_gpu_id,
             } => {
+                // Update has_connector before computing default plots
+                if stats.power_connector.is_some() && !self.has_connector {
+                    self.has_connector = true;
+                }
                 if let Some(selected_gpu_id) = selected_gpu_id {
                     self.stats_data.write().unwrap().clear();
 
@@ -213,10 +220,18 @@ impl relm4::Component for GraphsWindow {
                         .get(&selected_gpu_id)
                         .map(|config| config.plots.clone())
                         .filter(|plots| !plots.is_empty())
-                        .unwrap_or_else(default_plots);
+                        .unwrap_or_else(|| default_plots(self.has_connector));
 
                     self.gpu_id = Some(selected_gpu_id);
                     sender.input(GraphsWindowMsg::SetConfig(plots_config));
+                } else if stats.power_connector.is_some() {
+                    // GPU already selected: add connector plot if not present yet
+                    let already_present = self.plots.iter().any(|p| {
+                        p.selected_stats().iter().any(|s| matches!(s, StatType::ConnectorPin(_)))
+                    });
+                    if !already_present {
+                        sender.input(GraphsWindowMsg::AddConnectorPlot);
+                    }
                 }
 
                 let mut data = self.stats_data.write().unwrap();
@@ -281,6 +296,24 @@ impl relm4::Component for GraphsWindow {
                     });
                 }
             }
+            GraphsWindowMsg::AddConnectorPlot => {
+                let connector_plot = vec![
+                    StatType::ConnectorPin(0),
+                    StatType::ConnectorPin(1),
+                    StatType::ConnectorPin(2),
+                    StatType::ConnectorPin(3),
+                    StatType::ConnectorPin(4),
+                    StatType::ConnectorPin(5),
+                ];
+                sender.input(GraphsWindowMsg::SetConfig({
+                    let mut current: Vec<Vec<StatType>> = self.plots
+                        .iter()
+                        .map(|p| p.selected_stats())
+                        .collect();
+                    current.push(connector_plot);
+                    current
+                }));
+            }
             GraphsWindowMsg::ExportData => {
                 let settings = SaveDialogSettings {
                     cancel_label: "Cancel".to_owned(),
@@ -342,8 +375,8 @@ impl GraphsWindow {
 #[boxed_type(name = "DynamicIndexValue")]
 pub struct DynamicIndexValue(DynamicIndex);
 
-fn default_plots() -> Vec<Vec<StatType>> {
-    vec![
+fn default_plots(has_connector: bool) -> Vec<Vec<StatType>> {
+    let mut plots = vec![
         vec![
             StatType::Temperature("GPU".into()),
             StatType::Temperature("GPU Hotspot".into()),
@@ -363,7 +396,18 @@ fn default_plots() -> Vec<Vec<StatType>> {
             StatType::PowerCurrent,
             StatType::PowerCap,
         ],
-    ]
+    ];
+    if has_connector {
+        plots.push(vec![
+            StatType::ConnectorPin(0),
+            StatType::ConnectorPin(1),
+            StatType::ConnectorPin(2),
+            StatType::ConnectorPin(3),
+            StatType::ConnectorPin(4),
+            StatType::ConnectorPin(5),
+        ]);
+    }
+    plots
 }
 
 fn export_to_file(data: &StatsData, path: &Path) -> anyhow::Result<()> {

--- a/lact-gui/src/app/graphs_window/plot/render_thread.rs
+++ b/lact-gui/src/app/graphs_window/plot/render_thread.rs
@@ -236,8 +236,13 @@ impl RenderRequest {
             .max_by(|x, y| x.partial_cmp(y).unwrap_or(cmp::Ordering::Equal))
             .unwrap_or_default();
 
-        if maximum_value < 100.0 {
-            maximum_value = 100.0;
+        let y_minimum = if self.stats.iter().all(|s| matches!(s, StatType::ConnectorPin(_))) {
+            10.0
+        } else {
+            100.0
+        };
+        if maximum_value < y_minimum {
+            maximum_value = y_minimum;
         }
 
         root.fill(&self.colors.background)?; // Fill the background with white color.

--- a/lact-gui/src/app/graphs_window/stat.rs
+++ b/lact-gui/src/app/graphs_window/stat.rs
@@ -103,6 +103,14 @@ impl StatsData {
                     .push((timestamp, value));
             }
         }
+        if let Some(connector) = &stats.power_connector {
+            for (i, pin) in connector.pins.iter().enumerate() {
+                self.stats
+                    .entry(StatType::ConnectorPin(i))
+                    .or_default()
+                    .push((timestamp, pin.current_a()));
+            }
+        }
 
         let is_throttling = stats
             .throttle_info
@@ -229,6 +237,7 @@ pub enum StatType {
     GpuVoltage,
     Clockspeed(String),
     Voltage(String),
+    ConnectorPin(usize),
 }
 
 impl StatType {
@@ -251,6 +260,7 @@ impl StatType {
             PowerCurrent => "Power Draw".into(),
             PowerAverage => "Power Draw (Avg)".into(),
             PowerCap => "Power Cap".into(),
+            ConnectorPin(n) => format!("Connector Pin {}", n + 1).into(),
         }
     }
 
@@ -265,11 +275,12 @@ impl StatType {
             FanPwm => "%",
             GpuUsage => "%",
             PowerCurrent | PowerAverage | PowerCap | Power(_) => "W",
+            ConnectorPin(_) => "A",
         }
     }
 
     pub fn show_peak(&self) -> bool {
         use StatType::*;
-        !matches!(self, VramSize | PowerCap)
+!matches!(self, VramSize | PowerCap | ConnectorPin(_))
     }
 }

--- a/lact-gui/src/app/pages/oc_page/gpu_stats_section.rs
+++ b/lact-gui/src/app/pages/oc_page/gpu_stats_section.rs
@@ -9,7 +9,7 @@ use crate::app::{
 use gtk::pango::AttrList;
 use gtk::prelude::{BoxExt, Cast, FlowBoxChildExt, OrientableExt, PopoverExt as _, WidgetExt};
 use i18n_embed_fl::fl;
-use lact_schema::{DeviceInfo, DeviceStats, PowerStates, PowerStats};
+use lact_schema::{DeviceInfo, DeviceStats, PowerConnectorStats, PowerStates, PowerStats};
 use relm4::{ComponentParts, ComponentSender, RelmWidgetExt as _};
 use std::str::FromStr as _;
 use std::sync::Arc;
@@ -23,6 +23,7 @@ pub struct GpuStatsSection {
     max_vram_clock: Option<u64>,
     min_gpu_clock: Option<u64>,
     min_vram_clock: Option<u64>,
+    power_connector: Option<PowerConnectorStats>,
 }
 
 #[derive(Debug)]
@@ -271,7 +272,87 @@ impl relm4::SimpleComponent for GpuStatsSection {
                     },
                 },
             },
-        }
+
+            PageSection::new(&fl!(I18N, "connector-section-title")) {
+                #[watch]
+                set_visible: model.power_connector.is_some(),
+                append_child = &gtk::FlowBox {
+                    set_orientation: gtk::Orientation::Horizontal,
+                    set_column_spacing: 10,
+                    set_row_spacing: 10,
+                    set_homogeneous: true,
+                    set_selection_mode: gtk::SelectionMode::None,
+                    set_max_children_per_line: 2,
+
+                    append = &InfoRow {
+                        set_name: fl!(I18N, "connector-total-current"),
+                        #[watch]
+                        set_value: format!(
+                            "{} A",
+                            Mono::float(model.power_connector.as_ref().map(|c| c.total_current_a()).unwrap_or(0.0), 3)
+                        ),
+                    },
+
+                    append = &InfoRow {
+                        set_name: fl!(I18N, "connector-total-power"),
+                        #[watch]
+                        set_value: format!(
+                            "{} W",
+                            Mono::float(model.power_connector.as_ref().map(|c| c.total_power_w()).unwrap_or(0.0), 1)
+                        ),
+                    },
+
+                    append = &InfoRow {
+                        set_name: fl!(I18N, "connector-pin", n = 1),
+                        #[watch]
+                        set_value: model.power_connector.as_ref()
+                            .and_then(|c| c.pins.get(0))
+                            .map(|p| format!("{:.3} A", p.current_a()))
+                            .unwrap_or_default(),
+                    },
+                    append = &InfoRow {
+                        set_name: fl!(I18N, "connector-pin", n = 2),
+                        #[watch]
+                        set_value: model.power_connector.as_ref()
+                            .and_then(|c| c.pins.get(1))
+                            .map(|p| format!("{:.3} A", p.current_a()))
+                            .unwrap_or_default(),
+                    },
+                    append = &InfoRow {
+                        set_name: fl!(I18N, "connector-pin", n = 3),
+                        #[watch]
+                        set_value: model.power_connector.as_ref()
+                            .and_then(|c| c.pins.get(2))
+                            .map(|p| format!("{:.3} A", p.current_a()))
+                            .unwrap_or_default(),
+                    },
+                    append = &InfoRow {
+                        set_name: fl!(I18N, "connector-pin", n = 4),
+                        #[watch]
+                        set_value: model.power_connector.as_ref()
+                            .and_then(|c| c.pins.get(3))
+                            .map(|p| format!("{:.3} A", p.current_a()))
+                            .unwrap_or_default(),
+                    },
+                    append = &InfoRow {
+                        set_name: fl!(I18N, "connector-pin", n = 5),
+                        #[watch]
+                        set_value: model.power_connector.as_ref()
+                            .and_then(|c| c.pins.get(4))
+                            .map(|p| format!("{:.3} A", p.current_a()))
+                            .unwrap_or_default(),
+                    },
+                    append = &InfoRow {
+                        set_name: fl!(I18N, "connector-pin", n = 6),
+                        #[watch]
+                        set_value: model.power_connector.as_ref()
+                            .and_then(|c| c.pins.get(5))
+                            .map(|p| format!("{:.3} A", p.current_a()))
+                            .unwrap_or_default(),
+                    },
+                },
+            },
+        },
     }
 
     fn init(
@@ -293,6 +374,7 @@ impl relm4::SimpleComponent for GpuStatsSection {
             max_vram_clock: None,
             min_gpu_clock: None,
             min_vram_clock: None,
+            power_connector: None,
         };
 
         let widgets = view_output!();
@@ -358,6 +440,7 @@ impl relm4::SimpleComponent for GpuStatsSection {
                 }
             }
             GpuStatsSectionMsg::Stats(stats) => {
+                self.power_connector = stats.power_connector.clone();
                 self.stats = stats;
             }
             GpuStatsSectionMsg::PowerStates(pstates) => {

--- a/lact-gui/src/app/preferences_dialog.rs
+++ b/lact-gui/src/app/preferences_dialog.rs
@@ -8,7 +8,7 @@ use adw::prelude::{
     PreferencesRowExt,
 };
 use gtk::prelude::{
-    ButtonExt, EditableExt, ListBoxRowExt, OrientableExt, ToggleButtonExt, WidgetExt,
+    ButtonExt, EditableExt, EntryExt, ListBoxRowExt, OrientableExt, ToggleButtonExt, WidgetExt,
 };
 use i18n_embed_fl::fl;
 use lact_schema::SystemInfo;
@@ -23,6 +23,10 @@ pub struct PreferencesDialog {
 pub enum PreferencesDialogMsg {
     Show,
     ThemeSelected(AppTheme),
+    AlarmThresholdChanged(f64),
+    AlarmNotifyToggled(bool),
+    AlarmCommandChanged(String),
+    AlarmCommandToggled(bool),
 }
 
 #[relm4::component(pub)]
@@ -141,6 +145,51 @@ impl relm4::Component for PreferencesDialog {
                         },
                     },
                 },
+
+                add = &adw::PreferencesGroup {
+                    set_title: &fl!(I18N, "connector-alarm-group"),
+
+                    adw::ActionRow {
+                        set_title: &fl!(I18N, "connector-alarm-threshold"),
+                        set_subtitle: &fl!(I18N, "connector-alarm-threshold-subtitle"),
+
+                        add_suffix = &gtk::SpinButton {
+                            set_range: (1.0, 10.0),
+                            set_increments: (0.5, 1.0),
+                            set_digits: 1,
+                            set_width_chars: 4,
+                            set_valign: gtk::Align::Center,
+                            set_value: CONFIG.read().connector_alarm.as_ref().map(|a| a.pin_current_threshold_a).unwrap_or(8.0),
+                            connect_value_changed[sender] => move |btn| {
+                                sender.input(PreferencesDialogMsg::AlarmThresholdChanged(btn.value()));
+                            },
+                        },
+                    },
+
+                    adw::SwitchRow {
+                        set_title: &fl!(I18N, "connector-alarm-notify"),
+                        #[watch]
+                        set_active: CONFIG.read().connector_alarm.as_ref().map(|a| a.notify).unwrap_or(true),
+                        connect_active_notify[sender] => move |row| {
+                            sender.input(PreferencesDialogMsg::AlarmNotifyToggled(row.is_active()));
+                        },
+                    },
+
+                    adw::ActionRow {
+                        set_title: &fl!(I18N, "connector-alarm-command"),
+                        set_subtitle: &fl!(I18N, "connector-alarm-command-subtitle"),
+
+                        add_suffix = &gtk::Entry {
+                            set_placeholder_text: Some(&fl!(I18N, "connector-alarm-command-placeholder")),
+                            set_width_chars: 30,
+                            set_valign: gtk::Align::Center,
+                            set_text: &CONFIG.read().connector_alarm.as_ref().and_then(|a| a.command.clone()).unwrap_or_default(),
+                            connect_changed[sender] => move |entry| {
+                                sender.input(PreferencesDialogMsg::AlarmCommandChanged(entry.text().to_string()));
+                            },
+                        },
+                    },
+                },
             },
         }
     }
@@ -176,6 +225,23 @@ impl relm4::Component for PreferencesDialog {
                     config.theme = theme;
                 });
             }
+            PreferencesDialogMsg::AlarmThresholdChanged(value) => {
+                CONFIG.write().edit(|config| {
+                    config.connector_alarm.get_or_insert_with(Default::default).pin_current_threshold_a = value;
+                });
+            }
+            PreferencesDialogMsg::AlarmNotifyToggled(active) => {
+                CONFIG.write().edit(|config| {
+                    config.connector_alarm.get_or_insert_with(Default::default).notify = active;
+                });
+            }
+            PreferencesDialogMsg::AlarmCommandChanged(cmd) => {
+                CONFIG.write().edit(|config| {
+                    let alarm = config.connector_alarm.get_or_insert_with(Default::default);
+                    alarm.command = if cmd.is_empty() { None } else { Some(cmd) };
+                });
+            }
+            PreferencesDialogMsg::AlarmCommandToggled(_) => {}
         }
         self.update_view(widgets, sender);
     }

--- a/lact-gui/src/config.rs
+++ b/lact-gui/src/config.rs
@@ -24,6 +24,8 @@ pub struct UiConfig {
     pub gpus: HashMap<String, UiGpuConfig>,
     #[serde(default)]
     pub theme: AppTheme,
+    #[serde(default)]
+    pub connector_alarm: Option<ConnectorAlarmConfig>,
 }
 
 impl Default for UiConfig {
@@ -36,6 +38,7 @@ impl Default for UiConfig {
             stats_poll_interval_ms: default_stats_poll_interval(),
             gpus: HashMap::new(),
             theme: AppTheme::Automatic,
+            connector_alarm: None,
         }
     }
 }
@@ -110,4 +113,22 @@ fn deserialize_poll_interval<'de, D: Deserializer<'de>>(deserializer: D) -> Resu
 
 fn default_tab() -> String {
     "info_page".to_owned()
+}
+
+#[skip_serializing_none]
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ConnectorAlarmConfig {
+    pub pin_current_threshold_a: f64,
+    pub notify: bool,
+    pub command: Option<String>,
+}
+
+impl Default for ConnectorAlarmConfig {
+    fn default() -> Self {
+        Self {
+            pin_current_threshold_a: 8.0,
+            notify: true,
+            command: None,
+        }
+    }
 }

--- a/lact-schema/src/config.rs
+++ b/lact-schema/src/config.rs
@@ -49,6 +49,7 @@ pub struct GpuConfig {
     pub custom_power_profile_mode_hueristics: Vec<Vec<Option<i32>>>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub power_states: IndexMap<PowerLevelKind, Vec<u8>>,
+    pub power_connector: Option<PowerConnectorConfig>,
 }
 
 #[skip_serializing_none]
@@ -238,3 +239,16 @@ mod tests {
         );
     }
 }
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PowerConnectorConfig {
+    pub i2c_bus: u8,
+    #[serde(default = "default_i2c_addr")]
+    pub i2c_addr: u8,
+    #[serde(default = "default_reg_base")]
+    pub reg_base: u8,
+}
+
+fn default_i2c_addr() -> u8 { 0x2b }
+fn default_reg_base() -> u8 { 0x80 }

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -553,6 +553,8 @@ pub struct DeviceStats {
     pub memory_power_state: Option<usize>,
     pub pcie_power_state: Option<usize>,
     pub throttle_info: Option<BTreeMap<String, Vec<String>>>,
+    #[serde(default)]
+    pub power_connector: Option<PowerConnectorStats>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -851,4 +853,36 @@ impl ProcessUtilizationType {
 pub enum ProcessType {
     Graphics,
     Compute,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct ConnectorPinStats {
+    pub voltage_mv: u32,
+    pub current_ma: u32,
+}
+
+impl ConnectorPinStats {
+    pub fn voltage_v(&self) -> f64 {
+        self.voltage_mv as f64 / 1000.0
+    }
+    pub fn current_a(&self) -> f64 {
+        self.current_ma as f64 / 1000.0
+    }
+    pub fn power_w(&self) -> f64 {
+        self.voltage_v() * self.current_a()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct PowerConnectorStats {
+    pub pins: Vec<ConnectorPinStats>,
+}
+
+impl PowerConnectorStats {
+    pub fn total_current_a(&self) -> f64 {
+        self.pins.iter().map(|p| p.current_a()).sum()
+    }
+    pub fn total_power_w(&self) -> f64 {
+        self.pins.iter().map(|p| p.power_w()).sum()
+    }
 }


### PR DESCRIPTION
## Summary
Adds real-time monitoring of the 12VHPWR/12V-2x6 power connector current 
for supported NVIDIA GPUs (currently confirmed on ASUS RTX 5090 Astral/Matrix).

## How it works
The connector exposes per-pin current and voltage data via SMBus/I2C 
(default address 0x2b, register base 0x80). This is configured per-GPU 
in the daemon config.

## Configuration
Add to `/etc/lact/config.yaml` under the GPU entry:
```yaml
gpus:
  <gpu-id>:
    power_connector:
      i2c_bus: N  # find with: sudo i2cdetect -l
```

## Features
- Per-pin current display in OC page (6 pins, 2-column layout)
- Total current and total power summary
- Historical graphs with appropriate 10A Y-axis limit
- Configurable alarm: threshold, desktop notification, custom command
- Full i18n support

## Hardware compatibility
Tested on ASUS RTX 5090 Astral OC. Should work on any GPU where the 
12VHPWR controller is accessible at I2C address 0x2b.
Known compatible: ASUS Astral, ASUS Matrix series.