### PR TITLE
feat: add hold/release cookie mechanism for profile state management

### DIFF
--- a/lact-client/src/lib.rs
+++ b/lact-client/src/lib.rs
@@ -172,6 +172,15 @@ impl DaemonClient {
             .await
     }
 
+    pub async fn hold_profile(&self, name: String, requester: String) -> anyhow::Result<u64> {
+        self.make_request(Request::HoldProfile { name, requester })
+            .await
+    }
+
+    pub async fn release_profile(&self, cookie: u64) -> anyhow::Result<()> {
+        self.make_request(Request::ReleaseProfile { cookie }).await
+    }
+
     pub async fn evaluate_profile_rule(&self, rule: ProfileRule) -> anyhow::Result<bool> {
         self.make_request(Request::EvaluateProfileRule { rule })
             .await

--- a/lact-client/src/lib.rs
+++ b/lact-client/src/lib.rs
@@ -172,9 +172,8 @@ impl DaemonClient {
             .await
     }
 
-    pub async fn hold_profile(&self, name: String, requester: String) -> anyhow::Result<u64> {
-        self.make_request(Request::HoldProfile { name, requester })
-            .await
+    pub async fn hold_profile(&self, name: String) -> anyhow::Result<u64> {
+        self.make_request(Request::HoldProfile { name }).await
     }
 
     pub async fn release_profile(&self, cookie: u64) -> anyhow::Result<()> {

--- a/lact-daemon/src/server.rs
+++ b/lact-daemon/src/server.rs
@@ -15,6 +15,7 @@ use std::fmt::Debug;
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader},
     net::{TcpListener, UnixListener},
+    sync::watch,
 };
 use tracing::{debug, error, info, instrument, trace};
 
@@ -116,6 +117,8 @@ pub async fn handle_stream<T: AsyncRead + AsyncWrite + Unpin>(
     stream: T,
     handler: Handler,
 ) -> anyhow::Result<()> {
+    let (_disconnect_tx, disconnect_rx) = watch::channel(false);
+
     let mut stream = BufReader::new(stream);
 
     let mut buf = String::new();
@@ -124,7 +127,7 @@ pub async fn handle_stream<T: AsyncRead + AsyncWrite + Unpin>(
 
         let maybe_request = serde_json::from_str(&buf);
         let response = match maybe_request {
-            Ok(request) => match handle_request(request, &handler).await {
+            Ok(request) => match handle_request(request, &handler, &disconnect_rx).await {
                 Ok(response) => response,
                 Err(error) => serde_json::to_vec(&Response::<()>::from(error))?,
             },
@@ -142,8 +145,12 @@ pub async fn handle_stream<T: AsyncRead + AsyncWrite + Unpin>(
     Ok(())
 }
 
-#[instrument(level = "debug", skip(handler))]
-async fn handle_request<'a>(request: Request<'a>, handler: &'a Handler) -> anyhow::Result<Vec<u8>> {
+#[instrument(level = "debug", skip(handler, disconnect_rx))]
+async fn handle_request<'a>(
+    request: Request<'a>,
+    handler: &'a Handler,
+    disconnect_rx: &watch::Receiver<bool>,
+) -> anyhow::Result<Vec<u8>> {
     match request {
         Request::Ping => ok_response(ping()),
         Request::SystemInfo => ok_response(system::info().await?),
@@ -198,6 +205,12 @@ async fn handle_request<'a>(request: Request<'a>, handler: &'a Handler) -> anyho
         Request::DeleteProfile { name } => ok_response(handler.delete_profile(name).await?),
         Request::MoveProfile { name, new_position } => {
             ok_response(handler.move_profile(&name, new_position).await?)
+        }
+        Request::HoldProfile { name, requester } => {
+            ok_response(handler.hold_profile(name, requester, disconnect_rx.clone()).await?)
+        }
+        Request::ReleaseProfile { cookie } => {
+            ok_response(handler.release_profile(cookie).await?)
         }
         Request::EvaluateProfileRule { rule } => ok_response(handler.evaluate_profile_rule(&rule)?),
         Request::SetProfileRule { name, rule, hooks } => {

--- a/lact-daemon/src/server.rs
+++ b/lact-daemon/src/server.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader},
     net::{TcpListener, UnixListener},
-    sync::watch,
+    sync::Notify,
 };
 use tracing::{debug, error, info, instrument, trace};
 
@@ -117,7 +117,7 @@ pub async fn handle_stream<T: AsyncRead + AsyncWrite + Unpin>(
     stream: T,
     handler: Handler,
 ) -> anyhow::Result<()> {
-    let (_disconnect_tx, disconnect_rx) = watch::channel(false);
+    let disconnect_notify = std::sync::Arc::new(Notify::new());
 
     let mut stream = BufReader::new(stream);
 
@@ -127,7 +127,7 @@ pub async fn handle_stream<T: AsyncRead + AsyncWrite + Unpin>(
 
         let maybe_request = serde_json::from_str(&buf);
         let response = match maybe_request {
-            Ok(request) => match handle_request(request, &handler, &disconnect_rx).await {
+            Ok(request) => match handle_request(request, &handler, &disconnect_notify).await {
                 Ok(response) => response,
                 Err(error) => serde_json::to_vec(&Response::<()>::from(error))?,
             },
@@ -142,14 +142,16 @@ pub async fn handle_stream<T: AsyncRead + AsyncWrite + Unpin>(
         buf.clear();
     }
 
+    disconnect_notify.notify_waiters();
+
     Ok(())
 }
 
-#[instrument(level = "debug", skip(handler, disconnect_rx))]
+#[instrument(level = "debug", skip(handler, disconnect_notify))]
 async fn handle_request<'a>(
     request: Request<'a>,
     handler: &'a Handler,
-    disconnect_rx: &watch::Receiver<bool>,
+    disconnect_notify: &std::sync::Arc<Notify>,
 ) -> anyhow::Result<Vec<u8>> {
     match request {
         Request::Ping => ok_response(ping()),
@@ -206,9 +208,11 @@ async fn handle_request<'a>(
         Request::MoveProfile { name, new_position } => {
             ok_response(handler.move_profile(&name, new_position).await?)
         }
-        Request::HoldProfile { name } => {
-            ok_response(handler.hold_profile(name, disconnect_rx.clone()).await?)
-        }
+        Request::HoldProfile { name } => ok_response(
+            handler
+                .hold_profile(name, disconnect_notify.clone())
+                .await?,
+        ),
         Request::ReleaseProfile { cookie } => ok_response(handler.release_profile(cookie).await?),
         Request::EvaluateProfileRule { rule } => ok_response(handler.evaluate_profile_rule(&rule)?),
         Request::SetProfileRule { name, rule, hooks } => {

--- a/lact-daemon/src/server.rs
+++ b/lact-daemon/src/server.rs
@@ -206,12 +206,10 @@ async fn handle_request<'a>(
         Request::MoveProfile { name, new_position } => {
             ok_response(handler.move_profile(&name, new_position).await?)
         }
-        Request::HoldProfile { name, requester } => {
-            ok_response(handler.hold_profile(name, requester, disconnect_rx.clone()).await?)
+        Request::HoldProfile { name } => {
+            ok_response(handler.hold_profile(name, disconnect_rx.clone()).await?)
         }
-        Request::ReleaseProfile { cookie } => {
-            ok_response(handler.release_profile(cookie).await?)
-        }
+        Request::ReleaseProfile { cookie } => ok_response(handler.release_profile(cookie).await?),
         Request::EvaluateProfileRule { rule } => ok_response(handler.evaluate_profile_rule(&rule)?),
         Request::SetProfileRule { name, rule, hooks } => {
             ok_response(handler.set_profile_rule(&name, rule, hooks).await?)

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -47,7 +47,7 @@ use std::{
 };
 use tokio::{
     process::Command,
-    sync::{RwLock, RwLockReadGuard, mpsc, oneshot},
+    sync::{RwLock, RwLockReadGuard, mpsc, oneshot, watch},
     task::JoinHandle,
     time::sleep,
 };
@@ -92,6 +92,9 @@ pub struct Handler {
     profile_watcher_tx: Rc<RefCell<Option<mpsc::Sender<ProfileWatcherCommand>>>>,
     pub profile_watcher_state: Rc<RefCell<Option<ProfileWatcherState>>>,
     profile_watcher_join_handle: Rc<RefCell<Option<JoinHandle<()>>>>,
+    profile_holds: Rc<RefCell<Vec<(u64, Rc<str>, oneshot::Sender<()>)>>>,
+    profile_hold_snapshot: Rc<RefCell<Option<(Option<Rc<str>>, bool)>>>,
+    next_hold_cookie: Rc<Cell<u64>>,
 }
 
 impl<'a> Handler {
@@ -177,6 +180,9 @@ impl<'a> Handler {
             profile_watcher_tx: Rc::new(RefCell::new(None)),
             profile_watcher_state: Rc::new(RefCell::new(None)),
             profile_watcher_join_handle: Rc::new(RefCell::new(None)),
+            profile_holds: Rc::new(RefCell::new(Vec::new())),
+            profile_hold_snapshot: Rc::new(RefCell::new(None)),
+            next_hold_cookie: Rc::new(Cell::new(1)),
         };
         if let Err(err) = handler.apply_current_config().await {
             error!("could not apply config: {err:#}");
@@ -817,6 +823,9 @@ impl<'a> Handler {
         name: Option<Rc<str>>,
         auto_switch: bool,
     ) -> anyhow::Result<()> {
+        if !self.profile_holds.borrow().is_empty() {
+            bail!("Cannot change profile while a hold is active");
+        }
         if auto_switch {
             self.start_profile_watcher().await;
         } else {
@@ -890,6 +899,14 @@ impl<'a> Handler {
     }
 
     pub async fn delete_profile(&self, name: String) -> anyhow::Result<()> {
+        if self
+            .profile_holds
+            .borrow()
+            .iter()
+            .any(|(_, n, _)| n.as_ref() == name.as_str())
+        {
+            bail!("Cannot delete profile '{name}' while it is held");
+        }
         if self.config.read().await.current_profile.as_deref() == Some(&name) {
             self.set_current_profile(None).await?;
         }
@@ -997,6 +1014,110 @@ impl<'a> Handler {
         } else {
             Err(anyhow!("No pending config changes"))
         }
+    }
+
+    pub async fn hold_profile(
+        &self,
+        name: String,
+        requester: String,
+        mut disconnect_rx: watch::Receiver<bool>,
+    ) -> anyhow::Result<u64> {
+        {
+            let config = self.config.read().await;
+            config.profile(&name)?;
+        }
+
+        // On the first hold, snapshot the current state and stop the watcher.
+        if self.profile_holds.borrow().is_empty() {
+            let (snapshot_profile, snapshot_auto_switch) = {
+                let config = self.config.read().await;
+                (config.current_profile.clone(), config.auto_switch_profiles)
+            };
+            self.config.write().await.auto_switch_profiles = false;
+            self.stop_profile_watcher().await;
+            *self.profile_hold_snapshot.borrow_mut() = Some((snapshot_profile, snapshot_auto_switch));
+        }
+
+        let name_rc: Rc<str> = Rc::from(name.as_str());
+
+        let cookie = self.next_hold_cookie.get();
+        self.next_hold_cookie.set(cookie + 1);
+
+        let (drop_guard_tx, drop_guard_rx) = oneshot::channel::<()>();
+        self.profile_holds
+            .borrow_mut()
+            .push((cookie, name_rc.clone(), drop_guard_tx));
+
+        if let Err(err) = self.set_current_profile(Some(name_rc)).await {
+            self.profile_holds.borrow_mut().retain(|(c, _, _)| *c != cookie);
+            if self.profile_holds.borrow().is_empty() {
+                self.profile_hold_snapshot.borrow_mut().take();
+            }
+            return Err(err);
+        }
+
+        info!("profile hold {cookie} acquired by '{requester}' for profile '{name}'");
+
+        let handler = self.clone();
+        tokio::task::spawn_local(async move {
+            tokio::select! {
+                _ = disconnect_rx.wait_for(|_| false) => {
+                    debug!("connection for profile hold {cookie} dropped, auto-releasing");
+                }
+                _ = drop_guard_rx => {
+                    return;
+                }
+            }
+            if let Err(err) = handler.release_profile(cookie).await {
+                error!("could not auto-release profile hold {cookie}: {err:#}");
+            }
+        });
+
+        Ok(cookie)
+    }
+
+    pub async fn release_profile(&self, cookie: u64) -> anyhow::Result<()> {
+        let was_top = {
+            let holds = self.profile_holds.borrow();
+            match holds.iter().rposition(|(c, _, _)| *c == cookie) {
+                Some(idx) => idx == holds.len() - 1,
+                None => bail!("Unknown profile hold cookie {cookie}"),
+            }
+        };
+
+        self.profile_holds.borrow_mut().retain(|(c, _, _)| *c != cookie);
+
+        info!("releasing profile hold {cookie}");
+
+        if self.profile_holds.borrow().is_empty() {
+            // Last hold released, restore the previous state.
+            let (profile, auto_switch) = self
+                .profile_hold_snapshot
+                .borrow_mut()
+                .take()
+                .expect("snapshot missing while holds were active");
+
+            self.set_current_profile(profile).await?;
+
+            if auto_switch {
+                self.start_profile_watcher().await;
+            }
+
+            let mut config = self.config.write().await;
+            config.auto_switch_profiles = auto_switch;
+            config.save(&self.config_last_saved)?;
+        } else if was_top {
+            // Active hold released, activate the hold beneath it.
+            let target = self
+                .profile_holds
+                .borrow()
+                .last()
+                .map(|(_, name, _)| name.clone())
+                .unwrap();
+            self.set_current_profile(Some(target)).await?;
+        }
+
+        Ok(())
     }
 
     pub async fn reset_config(&self) {

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -1022,7 +1022,6 @@ impl<'a> Handler {
     pub async fn hold_profile(
         &self,
         name: String,
-        requester: String,
         mut disconnect_rx: watch::Receiver<bool>,
     ) -> anyhow::Result<u64> {
         {
@@ -1038,7 +1037,8 @@ impl<'a> Handler {
             };
             self.config.write().await.auto_switch_profiles = false;
             self.stop_profile_watcher().await;
-            *self.profile_hold_snapshot.borrow_mut() = Some((snapshot_profile, snapshot_auto_switch));
+            *self.profile_hold_snapshot.borrow_mut() =
+                Some((snapshot_profile, snapshot_auto_switch));
         }
 
         let name_rc: Rc<str> = Rc::from(name.as_str());
@@ -1052,14 +1052,16 @@ impl<'a> Handler {
             .push((cookie, name_rc.clone(), drop_guard_tx));
 
         if let Err(err) = self.set_current_profile(Some(name_rc)).await {
-            self.profile_holds.borrow_mut().retain(|(c, _, _)| *c != cookie);
+            self.profile_holds
+                .borrow_mut()
+                .retain(|(c, _, _)| *c != cookie);
             if self.profile_holds.borrow().is_empty() {
                 self.profile_hold_snapshot.borrow_mut().take();
             }
             return Err(err);
         }
 
-        info!("profile hold {cookie} acquired by '{requester}' for profile '{name}'");
+        info!("profile hold {cookie} acquired for profile '{name}'");
 
         let handler = self.clone();
         tokio::task::spawn_local(async move {
@@ -1088,7 +1090,9 @@ impl<'a> Handler {
             }
         };
 
-        self.profile_holds.borrow_mut().retain(|(c, _, _)| *c != cookie);
+        self.profile_holds
+            .borrow_mut()
+            .retain(|(c, _, _)| *c != cookie);
 
         info!("releasing profile hold {cookie}");
 

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -47,7 +47,7 @@ use std::{
 };
 use tokio::{
     process::Command,
-    sync::{RwLock, RwLockReadGuard, mpsc, oneshot, watch},
+    sync::{RwLock, RwLockReadGuard, mpsc, oneshot},
     task::JoinHandle,
     time::sleep,
 };
@@ -83,7 +83,7 @@ const SNAPSHOT_EXCLUDED_FILENAME_PREFIXES: &[&str] = &[
 ];
 const CONFIG_RESET_CMDLINE_ARG: &str = "lact-reset";
 
-type ProfileHolds = Rc<RefCell<Vec<(u64, Rc<str>, oneshot::Sender<()>)>>>;
+type ProfileHolds = Rc<RefCell<Vec<(u64, Rc<str>, mpsc::Sender<()>)>>>;
 type ProfileHoldSnapshot = Rc<RefCell<Option<(Option<Rc<str>>, bool)>>>;
 
 #[derive(Clone)]
@@ -1022,7 +1022,7 @@ impl<'a> Handler {
     pub async fn hold_profile(
         &self,
         name: String,
-        mut disconnect_rx: watch::Receiver<bool>,
+        disconnect_notify: std::sync::Arc<tokio::sync::Notify>,
     ) -> anyhow::Result<u64> {
         {
             let config = self.config.read().await;
@@ -1046,10 +1046,10 @@ impl<'a> Handler {
         let cookie = self.next_hold_cookie.get();
         self.next_hold_cookie.set(cookie + 1);
 
-        let (drop_guard_tx, drop_guard_rx) = oneshot::channel::<()>();
+        let (release_tx, mut release_rx) = mpsc::channel::<()>(1);
         self.profile_holds
             .borrow_mut()
-            .push((cookie, name_rc.clone(), drop_guard_tx));
+            .push((cookie, name_rc.clone(), release_tx));
 
         if let Err(err) = self.set_current_profile(Some(name_rc)).await {
             self.profile_holds
@@ -1066,10 +1066,10 @@ impl<'a> Handler {
         let handler = self.clone();
         tokio::task::spawn_local(async move {
             tokio::select! {
-                _ = disconnect_rx.wait_for(|_| false) => {
+                () = disconnect_notify.notified() => {
                     debug!("connection for profile hold {cookie} dropped, auto-releasing");
                 }
-                _ = drop_guard_rx => {
+                _ = release_rx.recv() => {
                     return;
                 }
             }
@@ -1082,17 +1082,16 @@ impl<'a> Handler {
     }
 
     pub async fn release_profile(&self, cookie: u64) -> anyhow::Result<()> {
-        let was_top = {
+        let (idx, was_top) = {
             let holds = self.profile_holds.borrow();
             match holds.iter().rposition(|(c, _, _)| *c == cookie) {
-                Some(idx) => idx == holds.len() - 1,
+                Some(idx) => (idx, idx == holds.len() - 1),
                 None => bail!("Unknown profile hold cookie {cookie}"),
             }
         };
 
-        self.profile_holds
-            .borrow_mut()
-            .retain(|(c, _, _)| *c != cookie);
+        let (_, _, release_tx) = self.profile_holds.borrow_mut().remove(idx);
+        let _ = release_tx.send(()).await;
 
         info!("releasing profile hold {cookie}");
 

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -83,6 +83,9 @@ const SNAPSHOT_EXCLUDED_FILENAME_PREFIXES: &[&str] = &[
 ];
 const CONFIG_RESET_CMDLINE_ARG: &str = "lact-reset";
 
+type ProfileHolds = Rc<RefCell<Vec<(u64, Rc<str>, oneshot::Sender<()>)>>>;
+type ProfileHoldSnapshot = Rc<RefCell<Option<(Option<Rc<str>>, bool)>>>;
+
 #[derive(Clone)]
 pub struct Handler {
     pub config: Rc<RwLock<Config>>,
@@ -92,8 +95,8 @@ pub struct Handler {
     profile_watcher_tx: Rc<RefCell<Option<mpsc::Sender<ProfileWatcherCommand>>>>,
     pub profile_watcher_state: Rc<RefCell<Option<ProfileWatcherState>>>,
     profile_watcher_join_handle: Rc<RefCell<Option<JoinHandle<()>>>>,
-    profile_holds: Rc<RefCell<Vec<(u64, Rc<str>, oneshot::Sender<()>)>>>,
-    profile_hold_snapshot: Rc<RefCell<Option<(Option<Rc<str>>, bool)>>>,
+    profile_holds: ProfileHolds,
+    profile_hold_snapshot: ProfileHoldSnapshot,
     next_hold_cookie: Rc<Cell<u64>>,
 }
 

--- a/lact-schema/src/request.rs
+++ b/lact-schema/src/request.rs
@@ -85,6 +85,13 @@ pub enum Request<'a> {
         name: String,
         new_position: usize,
     },
+    HoldProfile {
+        name: String,
+        requester: String,
+    },
+    ReleaseProfile {
+        cookie: u64,
+    },
     EvaluateProfileRule {
         rule: ProfileRule,
     },

--- a/lact-schema/src/request.rs
+++ b/lact-schema/src/request.rs
@@ -87,7 +87,6 @@ pub enum Request<'a> {
     },
     HoldProfile {
         name: String,
-        requester: String,
     },
     ReleaseProfile {
         cookie: u64,


### PR DESCRIPTION
Clients that need to temporarily activate a profile had no safe way to restore the previous state on cleanup, and concurrent clients would silently overwrite each other's profile choice.

Introduce HoldProfile/ReleaseProfile commands modelled after power-profiles-daemon's HoldProfile/ReleaseProfile API. Acquiring a hold activates the requested profile and returns an opaque cookie; the previous state is saved automatically. Releasing the cookie restores it. Multiple concurrent holds are supported with last-write-wins semantics — releasing the active hold falls back to the next most recent one, and releasing the last hold restores the original state. If the client connection drops without releasing, the hold is released automatically.