### PR TITLE
Fix API documentation links

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ The general format of requests looks like:
 ```
 {"command": "command_name", "args": {}}
 ```
-Note that the type of `args` depends on the specific request, and may be ommited in some cases.
+Note that the type of `args` depends on the specific request, and may be omitted in some cases.
 
 The response looks like this:
 ```
@@ -69,7 +69,7 @@ The `power_cap` field has been changed from the previous config
 {"status":"ok","data":null}
 ```
 
-For the full list of available commands and responses, you can look at the source code of the schema: [requests](lact-schema/src/request.rs), [the basic response structure](lact-schema/src/response.rs) and [all possible types](lact-schema/src/lib.rs).
+For the full list of available commands and responses, you can look at the source code of the schema: [requests](../lact-schema/src/request.rs), [the basic response structure](../lact-schema/src/response.rs) and [all possible types](../lact-schema/src/lib.rs).
 
 It should also be fairly easy to figure out the API by trial and error, as the error message are quite verbose:
 

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -39,7 +39,7 @@ sudo rm /etc/systemd/system/lactd.service
 
 ## Implementation details
 
-The service uses [flatbox](github.com/ilya-zlobintsev/flatbox) in order to create a flatpak-like environment for the service that still has the permissions it needs to function (such as write access to various sysfs paths). Flatbox itself is shipped as a static binary with the flatpak and is executed on the host, which then discovers flatpak application/runtime/extension paths and sets them up for the service.
+The service uses [flatbox](https://github.com/ilya-zlobintsev/flatbox) in order to create a flatpak-like environment for the service that still has the permissions it needs to function (such as write access to various sysfs paths). Flatbox itself is shipped as a static binary with the flatpak and is executed on the host, which then discovers flatpak application/runtime/extension paths and sets them up for the service.
 
 This approach allows the service to avoid any dependence on system libraries and commands for its functionality. The only exception are distro-specific commands for AMD overdrive setup.
 


### PR DESCRIPTION
## Summary
- fix schema source links in docs/API.md so they resolve from the docs directory
- add the missing scheme to the flatbox link
- correct a small typo in the API description

## Verification
- checked local Markdown links in the changed files
- git diff --check