### PR TITLE
chore: improve p-state reads logs

### DIFF
--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -10,7 +10,7 @@ use crate::server::{
 use amdgpu_sysfs::{
     error::Error,
     gpu_handle::{
-        CommitHandle, GpuHandle, PerformanceLevel, PowerLevelKind, PowerLevels,
+        CommitHandle, GpuHandle, PerformanceLevel, PowerLevelKind,
         fan_control::FanCurve as PmfwCurve,
         overdrive::{ClocksTable, ClocksTableGen},
         power_profile_mode::PowerProfileModesTable,
@@ -436,14 +436,13 @@ impl AmdGpuController {
         attempt: u32,
     ) -> Vec<PowerState> {
         let enabled_states = gpu_config.and_then(|gpu| gpu.power_states.get(&kind));
-        let levels = self
-            .handle
-            .get_clock_levels(kind)
-            .unwrap_or_else(|_| PowerLevels {
-                levels: Vec::new(),
-                active: None,
-            })
-            .levels;
+        let levels = match self.handle.get_clock_levels(kind) {
+            Ok(levels) => levels.levels,
+            Err(err) => {
+                debug!("could not read AMD {kind:?} power states: {err:#}");
+                Vec::new()
+            }
+        };
 
         if attempt < MAX_PSTATE_READ_ATTEMPTS
             && levels.iter().any(|value| *value >= u64::from(u16::MAX))
@@ -1016,21 +1015,27 @@ impl GpuController for AmdGpuController {
             temps,
             busy_percent: self.handle.get_busy_percent().ok(),
             performance_level: self.handle.get_power_force_performance_level().ok(),
-            core_power_state: self
-                .handle
-                .get_core_clock_levels()
-                .ok()
-                .and_then(|levels| levels.active),
-            memory_power_state: self
-                .handle
-                .get_memory_clock_levels()
-                .ok()
-                .and_then(|levels| levels.active),
-            pcie_power_state: self
-                .handle
-                .get_pcie_clock_levels()
-                .ok()
-                .and_then(|levels| levels.active),
+            core_power_state: match self.handle.get_core_clock_levels() {
+                Ok(levels) => levels.active,
+                Err(err) => {
+                    debug!("could not read active AMD core power state: {err:#}");
+                    None
+                }
+            },
+            memory_power_state: match self.handle.get_memory_clock_levels() {
+                Ok(levels) => levels.active,
+                Err(err) => {
+                    debug!("could not read active AMD memory power state: {err:#}");
+                    None
+                }
+            },
+            pcie_power_state: match self.handle.get_pcie_clock_levels() {
+                Ok(levels) => levels.active,
+                Err(err) => {
+                    debug!("could not read active AMD PCIe power state: {err:#}");
+                    None
+                }
+            },
             throttle_info,
         }
     }

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -437,9 +437,12 @@ impl AmdGpuController {
     ) -> Vec<PowerState> {
         let enabled_states = gpu_config.and_then(|gpu| gpu.power_states.get(&kind));
         let levels = match self.handle.get_clock_levels(kind) {
-            Ok(levels) => levels.levels,
+            Ok(power_levels) => {
+                trace!("{kind:?} power states: {power_levels:?}");
+                power_levels.levels
+            }
             Err(err) => {
-                debug!("could not read AMD {kind:?} power states: {err:#}");
+                debug!("could not get {kind:?} power states: {err:#}");
                 Vec::new()
             }
         };
@@ -447,7 +450,9 @@ impl AmdGpuController {
         if attempt < MAX_PSTATE_READ_ATTEMPTS
             && levels.iter().any(|value| *value >= u64::from(u16::MAX))
         {
-            debug!("GPU reported nonsensical p-state value, retrying");
+            debug!(
+                "GPU reported nonsensical {kind:?} power state values, retrying: {levels:?}"
+            );
             return self.get_power_states_kind(gpu_config, kind, attempt + 1);
         }
 
@@ -1018,21 +1023,21 @@ impl GpuController for AmdGpuController {
             core_power_state: match self.handle.get_core_clock_levels() {
                 Ok(levels) => levels.active,
                 Err(err) => {
-                    debug!("could not read active AMD core power state: {err:#}");
+                    debug!("could not get active core power state: {err:#}");
                     None
                 }
             },
             memory_power_state: match self.handle.get_memory_clock_levels() {
                 Ok(levels) => levels.active,
                 Err(err) => {
-                    debug!("could not read active AMD memory power state: {err:#}");
+                    debug!("could not get active memory power state: {err:#}");
                     None
                 }
             },
             pcie_power_state: match self.handle.get_pcie_clock_levels() {
                 Ok(levels) => levels.active,
                 Err(err) => {
-                    debug!("could not read active AMD PCIe power state: {err:#}");
+                    debug!("could not get active PCIe power state: {err:#}");
                     None
                 }
             },

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -436,16 +436,13 @@ impl AmdGpuController {
         attempt: u32,
     ) -> Vec<PowerState> {
         let enabled_states = gpu_config.and_then(|gpu| gpu.power_states.get(&kind));
-        let levels = match self.handle.get_clock_levels(kind) {
-            Ok(power_levels) => {
-                trace!("{kind:?} power states: {power_levels:?}");
-                power_levels.levels
-            }
-            Err(err) => {
-                debug!("could not get {kind:?} power states: {err:#}");
-                Vec::new()
-            }
-        };
+        let levels = self
+            .handle
+            .get_clock_levels(kind)
+            .inspect(|power_levels| trace!("{kind:?} power states: {power_levels:?}"))
+            .inspect_err(|err| debug!("could not get {kind:?} power states: {err:#}"))
+            .map(|power_levels| power_levels.levels)
+            .unwrap_or_default();
 
         if attempt < MAX_PSTATE_READ_ATTEMPTS
             && levels.iter().any(|value| *value >= u64::from(u16::MAX))
@@ -1018,27 +1015,24 @@ impl GpuController for AmdGpuController {
             temps,
             busy_percent: self.handle.get_busy_percent().ok(),
             performance_level: self.handle.get_power_force_performance_level().ok(),
-            core_power_state: match self.handle.get_core_clock_levels() {
-                Ok(levels) => levels.active,
-                Err(err) => {
-                    debug!("could not get active core power state: {err:#}");
-                    None
-                }
-            },
-            memory_power_state: match self.handle.get_memory_clock_levels() {
-                Ok(levels) => levels.active,
-                Err(err) => {
-                    debug!("could not get active memory power state: {err:#}");
-                    None
-                }
-            },
-            pcie_power_state: match self.handle.get_pcie_clock_levels() {
-                Ok(levels) => levels.active,
-                Err(err) => {
-                    debug!("could not get active PCIe power state: {err:#}");
-                    None
-                }
-            },
+            core_power_state: self
+                .handle
+                .get_core_clock_levels()
+                .inspect_err(|err| debug!("could not get active core power state: {err:#}"))
+                .ok()
+                .and_then(|levels| levels.active),
+            memory_power_state: self
+                .handle
+                .get_memory_clock_levels()
+                .inspect_err(|err| debug!("could not get active memory power state: {err:#}"))
+                .ok()
+                .and_then(|levels| levels.active),
+            pcie_power_state: self
+                .handle
+                .get_pcie_clock_levels()
+                .inspect_err(|err| debug!("could not get active PCIe power state: {err:#}"))
+                .ok()
+                .and_then(|levels| levels.active),
             throttle_info,
         }
     }

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -450,9 +450,7 @@ impl AmdGpuController {
         if attempt < MAX_PSTATE_READ_ATTEMPTS
             && levels.iter().any(|value| *value >= u64::from(u16::MAX))
         {
-            debug!(
-                "GPU reported nonsensical {kind:?} power state values, retrying: {levels:?}"
-            );
+            debug!("GPU reported nonsensical {kind:?} power state values, retrying: {levels:?}");
             return self.get_power_states_kind(gpu_config, kind, attempt + 1);
         }
 


### PR DESCRIPTION
ref #994 

currently p-state read/parse errors are silenced. This change will add error logs with debug enabled and dump p-states readings with trace enabled.