### PR TITLE
fix: avoid leaking amdgpu device descriptors on reload

### DIFF
--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -1410,7 +1410,7 @@ fn get_drm_handle(
     common: &CommonControllerInfo,
     libdrm_amdgpu: &LibDrmAmdgpu,
 ) -> anyhow::Result<DrmHandle> {
-    use std::os::unix::io::IntoRawFd;
+    use std::os::unix::io::AsRawFd;
 
     let path = common.get_drm_render()?;
     let drm_file = fs::OpenOptions::new()
@@ -1419,7 +1419,7 @@ fn get_drm_handle(
         .open(&path)
         .with_context(|| format!("Could not open drm file at {}", path.display()))?;
     let (handle, _, _) = libdrm_amdgpu
-        .init_device_handle(drm_file.into_raw_fd())
+        .init_device_handle(drm_file.as_raw_fd())
         .map_err(|err| anyhow!("Could not open drm handle, error code {err}"))?;
     Ok(handle)
 }


### PR DESCRIPTION
Fixes #919

See https://github.com/Umio-Yasuno/libdrm-amdgpu-sys-rs/pull/13 for details