### PR TITLE
fix: bump amdgpu-sysfs with deep sleep pstate handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amdgpu-sysfs"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c17fa9dd35c209d782edb0aca1bdf75ccbd37a2fcf989dfcec92733b32818de"
+checksum = "e50f319907827f2c8dcd43fd1472e6103384bc3e8764a370db3db7a4e983817f"
 dependencies = [
  "enum_dispatch",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 edition = "2024"
 
 [workspace.dependencies]
-amdgpu-sysfs = { version = "0.20.0", features = ["serde"] }
+amdgpu-sysfs = { version = "0.20.1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "3.18.0", default-features = false, features = [
     "macros",


### PR DESCRIPTION
Should fix #994

Brings in https://github.com/ilya-zlobintsev/amdgpu-sysfs-rs/pull/17