### PR TITLE
feat: optimize gui bootstrap

### DIFF
--- a/lact-gui/src/app.css
+++ b/lact-gui/src/app.css
@@ -1,6 +1,5 @@
 /* currently used for tests */
 .app {
-
 }
 
 .main-sidebar-container .sidebar {
@@ -13,4 +12,10 @@
 
 .main-sidebar-container .sidebar-section {
     margin: 4px 8px 8px 8px;
+}
+
+.bootstrap-spinner-large {
+    min-width: 64px;
+    min-height: 64px;
+    -gtk-icon-size: 64px;
 }

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -534,8 +534,6 @@ impl AsyncComponent for AppModel {
             if let Err(err) = model.update_gpu_data_full(gpu_id, sender.clone()).await {
                 sender.input(AppMsg::Error(Arc::new(err)));
             }
-        } else {
-            warn!("no GPUs found during startup");
         }
 
         let widgets = view_output!();

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -648,6 +648,18 @@ impl AppModel {
                 self.reload_profiles(state_sender).await?;
                 sender.input(AppMsg::ReloadData { full: false });
             }
+            AppMsg::ProfilesPolled(profiles) => {
+                let profiles_changed = self
+                    .profile_selector
+                    .model()
+                    .profiles_info_changed(profiles.as_ref());
+                self.profile_selector
+                    .emit(ProfileSelectorMsg::Profiles(profiles));
+
+                if profiles_changed {
+                    sender.input(AppMsg::ReloadData { full: false });
+                }
+            }
             AppMsg::SelectGpu(gpu_id) => {
                 Self::set_selected_gpu_id(gpu_id);
                 sender.input(AppMsg::ReloadData { full: true });
@@ -995,7 +1007,7 @@ impl AppModel {
         }
 
         self.profile_selector
-            .emit(ProfileSelectorMsg::Profiles(Box::new(profiles)));
+            .emit(ProfileSelectorMsg::Profiles(Arc::new(profiles)));
 
         Ok(())
     }
@@ -1138,7 +1150,6 @@ impl AppModel {
             gpu_id.to_owned(),
             self.daemon_client.clone(),
             sender,
-            self.profile_selector.sender().clone(),
         ));
 
         Ok(stats)
@@ -1360,7 +1371,6 @@ fn start_stats_update_loop(
     gpu_id: String,
     daemon_client: DaemonClient,
     sender: AsyncComponentSender<AppModel>,
-    profiles_sender: relm4::Sender<ProfileSelectorMsg>,
 ) -> glib::JoinHandle<()> {
     debug!("spawning new stats update task");
     relm4::spawn_local(async move {
@@ -1379,7 +1389,7 @@ fn start_stats_update_loop(
 
             match daemon_client.list_profiles(false).await {
                 Ok(profiles) => {
-                    let _ = profiles_sender.send(ProfileSelectorMsg::Profiles(Box::new(profiles)));
+                    sender.input(AppMsg::ProfilesPolled(Arc::new(profiles)));
                 }
                 Err(err) => {
                     error!("could not fetch profile info: {err:#}");

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -45,7 +45,7 @@ use gtk::{
 use i18n_embed_fl::fl;
 use lact_client::{ConnectionStatusMsg, DaemonClient, schema::DeviceListEntry};
 use lact_schema::{
-    DeviceFlag, DeviceStats, GIT_COMMIT, SystemInfo,
+    DeviceFlag, DeviceStats, DeviceType, GIT_COMMIT, SystemInfo,
     args::GuiArgs,
     config::{GpuConfig, Profile},
     request::{ConfirmCommand, ProfileBase, SetClocksCommand},
@@ -952,6 +952,12 @@ impl AppModel {
 
         let selected_gpu_id = configured_gpu_id
             .filter(|gpu_id| devices.iter().any(|device| device.id == *gpu_id))
+            .or_else(|| {
+                devices
+                    .iter()
+                    .find(|device| device.device_type == DeviceType::Dedicated)
+                    .map(|device| device.id.clone())
+            })
             .or_else(|| devices.first().map(|device| device.id.clone()))?;
 
         debug!("selecting gpu id {selected_gpu_id}");

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -43,9 +43,9 @@ use gtk::{
     glib::{self, ControlFlow, clone},
 };
 use i18n_embed_fl::fl;
-use lact_client::{ConnectionStatusMsg, DaemonClient, schema::DeviceListEntry};
+use lact_client::{ConnectionStatusMsg, DaemonClient};
 use lact_schema::{
-    DeviceFlag, DeviceStats, DeviceType, GIT_COMMIT, SystemInfo,
+    DeviceFlag, DeviceListEntry, DeviceStats, DeviceType, GIT_COMMIT, SystemInfo,
     args::GuiArgs,
     config::{GpuConfig, Profile},
     request::{ConfirmCommand, ProfileBase, SetClocksCommand},
@@ -442,7 +442,7 @@ impl AsyncComponent for AppModel {
             .list_devices()
             .await
             .expect("Could not list devices");
-        let initial_gpu_id = AppModel::initial_gpu_selection(&devices);
+        let initial_gpu_id = AppModel::init_gpu_selection(&devices);
 
         let version_mismatch_info = (system_info.version != GUI_VERSION
             || system_info.commit.as_deref() != Some(GIT_COMMIT))
@@ -954,7 +954,7 @@ impl AppModel {
         Ok(())
     }
 
-    fn initial_gpu_selection(devices: &[DeviceListEntry]) -> Option<String> {
+    fn init_gpu_selection(devices: &[DeviceListEntry]) -> Option<String> {
         let configured_gpu_id = CONFIG.read().selected_gpu.clone();
 
         let selected_gpu_id = configured_gpu_id

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -43,7 +43,7 @@ use gtk::{
     glib::{self, ControlFlow, clone},
 };
 use i18n_embed_fl::fl;
-use lact_client::{ConnectionStatusMsg, DaemonClient};
+use lact_client::{ConnectionStatusMsg, DaemonClient, schema::DeviceListEntry};
 use lact_schema::{
     DeviceFlag, DeviceStats, GIT_COMMIT, SystemInfo,
     args::GuiArgs,
@@ -64,8 +64,10 @@ use relm4::{
     RelmWidgetExt,
     binding::BoolBinding,
     css,
+    loading_widgets::LoadingWidgets,
     prelude::{AsyncComponent, AsyncComponentParts},
     tokio::{self, time::sleep},
+    view,
 };
 use relm4_components::{
     open_dialog::{OpenDialog, OpenDialogMsg, OpenDialogResponse, OpenDialogSettings},
@@ -96,7 +98,6 @@ pub struct AppModel {
     info_dialog: relm4::Controller<InfoDialog>,
 
     ui_sensitive: BoolBinding,
-    selected_gpu_index: u32,
 
     info_page: relm4::Controller<InformationPage>,
     oc_page: relm4::Controller<OcPage>,
@@ -356,11 +357,42 @@ impl AsyncComponent for AppModel {
         },
     }
 
+    fn init_loading_widgets(root: Self::Root) -> Option<LoadingWidgets> {
+        view! {
+            #[local]
+            root {
+                set_title: Some("LACT"),
+                set_default_size: (1100, 750),
+                set_icon_name: Some(APP_ID),
+
+                #[name = "loading_box"]
+                gtk::Box {
+                    set_orientation: gtk::Orientation::Vertical,
+                    set_valign: gtk::Align::Center,
+                    set_halign: gtk::Align::Center,
+
+                    gtk::Spinner {
+                        start: (),
+                    }
+                }
+            }
+        }
+
+        Some(LoadingWidgets::new(root, loading_box))
+    }
+
     async fn init(
         args: Self::Init,
         root: Self::Root,
         sender: AsyncComponentSender<Self>,
     ) -> AsyncComponentParts<Self> {
+        // 1. apply UI styles,
+        // 2. connect to daemon,
+        // 3. fetch system/device info,
+        // 4. resolve selected GPU,
+        // 5. build child components,
+        // 6. load profiles and initial GPU data.
+
         relm4::set_global_css_with_priority(
             styles::COMBINED_CSS,
             STYLE_PROVIDER_PRIORITY_APPLICATION,
@@ -413,6 +445,7 @@ impl AsyncComponent for AppModel {
             .list_devices()
             .await
             .expect("Could not list devices");
+        let initial_gpu_id = AppModel::initial_gpu_selection(&devices);
 
         let version_mismatch_info = (system_info.version != GUI_VERSION
             || system_info.commit.as_deref() != Some(GIT_COMMIT))
@@ -463,16 +496,14 @@ impl AsyncComponent for AppModel {
         let process_monitor_window = ProcessMonitorWindow::detach_default();
 
         let gpu_selector = GpuSelector::builder()
-            .launch(devices)
-            .forward(sender.input_sender(), |gpu_idx| {
-                AppMsg::GpuSelected(gpu_idx)
-            });
+            .launch((devices, initial_gpu_id.clone()))
+            .forward(sender.input_sender(), AppMsg::SelectGpu);
 
         let profile_selector = ProfileSelector::builder()
             .launch(())
             .forward(sender.input_sender(), |msg| msg);
 
-        let model = AppModel {
+        let mut model = AppModel {
             daemon_client,
             graphs_window,
             process_monitor_window,
@@ -488,13 +519,24 @@ impl AsyncComponent for AppModel {
             gpu_selector,
             profile_selector,
             ui_sensitive: BoolBinding::new(false),
-            selected_gpu_index: 0,
             stats_task_handle: None,
             settings_changed,
             system_info,
             device_flags: vec![],
             device_driver: String::new(),
         };
+
+        if let Err(err) = model.reload_profiles(None).await {
+            sender.input(AppMsg::Error(Arc::new(err)));
+        }
+
+        if let Some(gpu_id) = initial_gpu_id {
+            if let Err(err) = model.update_gpu_data_full(gpu_id, sender.clone()).await {
+                sender.input(AppMsg::Error(Arc::new(err)));
+            }
+        } else {
+            warn!("no GPUs found during startup");
+        }
 
         let widgets = view_output!();
 
@@ -537,8 +579,6 @@ impl AsyncComponent for AppModel {
         if let Some(info) = version_mismatch_info {
             model.info_dialog.emit(InfoDialogMsg::Show(Box::new(info)));
         }
-
-        sender.input(AppMsg::ReloadProfiles { state_sender: None });
 
         let task_sender = sender.clone();
         sender.command(move |_, shutdown| {
@@ -600,6 +640,7 @@ impl AppModel {
     ) -> Result<(), Arc<anyhow::Error>> {
         match msg {
             AppMsg::Error(err) => return Err(err),
+
             AppMsg::SettingsChanged => {
                 self.settings_changed.set_value(true);
             }
@@ -607,14 +648,14 @@ impl AppModel {
                 self.reload_profiles(state_sender).await?;
                 sender.input(AppMsg::ReloadData { full: false });
             }
-            AppMsg::GpuSelected(idx) => {
-                self.selected_gpu_index = idx;
+            AppMsg::SelectGpu(gpu_id) => {
+                Self::set_selected_gpu_id(gpu_id);
                 sender.input(AppMsg::ReloadData { full: true });
             }
             AppMsg::ReloadData { full } => {
                 self.settings_changed.set_value(false);
 
-                let gpu_id = self.current_gpu_id()?;
+                let gpu_id = self.get_selected_gpu_id()?;
                 if full {
                     self.update_gpu_data_full(gpu_id, sender).await?;
                 } else {
@@ -743,7 +784,7 @@ impl AppModel {
                 });
             }
             AppMsg::ApplyChanges => {
-                self.apply_settings(self.current_gpu_id()?, root, &sender)
+                self.apply_settings(self.get_selected_gpu_id()?, root, &sender)
                     .await
                     .inspect_err(|_| {
                         sender.input(AppMsg::ReloadData { full: false });
@@ -753,7 +794,7 @@ impl AppModel {
                 sender.input(AppMsg::ReloadData { full: false });
             }
             AppMsg::ResetClocks => {
-                let gpu_id = self.current_gpu_id()?;
+                let gpu_id = self.get_selected_gpu_id()?;
                 self.daemon_client
                     .set_clocks_value(&gpu_id, SetClocksCommand::reset())
                     .await?;
@@ -763,7 +804,7 @@ impl AppModel {
                 sender.input(AppMsg::ReloadData { full: false });
             }
             AppMsg::ResetPmfw => {
-                let gpu_id = self.current_gpu_id()?;
+                let gpu_id = self.get_selected_gpu_id()?;
                 self.daemon_client.reset_pmfw(&gpu_id).await?;
                 self.daemon_client
                     .confirm_pending_config(ConfirmCommand::Confirm)
@@ -778,7 +819,7 @@ impl AppModel {
                     .emit(ProcessMonitorWindowMsg::Show);
             }
             AppMsg::DumpVBios => {
-                self.dump_vbios(&self.current_gpu_id()?, root, sender.clone())
+                self.dump_vbios(&self.get_selected_gpu_id()?, root, sender.clone())
                     .await?;
             }
             AppMsg::DebugSnapshot => {
@@ -819,7 +860,7 @@ impl AppModel {
             }
             AppMsg::FetchProcessList => {
                 if self.process_monitor_window.widget().is_visible()
-                    && let Ok(gpu_id) = self.current_gpu_id()
+                    && let Ok(gpu_id) = self.get_selected_gpu_id()
                 {
                     match self.daemon_client.get_process_list(&gpu_id).await {
                         Ok(process_list) => {
@@ -906,7 +947,25 @@ impl AppModel {
         Ok(())
     }
 
-    fn current_gpu_id(&self) -> anyhow::Result<String> {
+    fn initial_gpu_selection(devices: &[DeviceListEntry]) -> Option<String> {
+        let configured_gpu_id = CONFIG.read().selected_gpu.clone();
+
+        let selected_gpu_id = configured_gpu_id
+            .filter(|gpu_id| devices.iter().any(|device| device.id == *gpu_id))
+            .or_else(|| devices.first().map(|device| device.id.clone()))?;
+
+        debug!("selecting gpu id {selected_gpu_id}");
+        Self::set_selected_gpu_id(selected_gpu_id.clone());
+        Some(selected_gpu_id)
+    }
+
+    fn set_selected_gpu_id(gpu_id: String) {
+        CONFIG.write().edit(|config| {
+            config.selected_gpu = Some(gpu_id);
+        });
+    }
+
+    fn get_selected_gpu_id(&self) -> anyhow::Result<String> {
         CONFIG
             .read()
             .selected_gpu

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -361,10 +361,6 @@ impl AsyncComponent for AppModel {
         view! {
             #[local]
             root {
-                set_title: Some("LACT"),
-                set_default_size: (1100, 750),
-                set_icon_name: Some(APP_ID),
-
                 #[name = "loading_box"]
                 gtk::Box {
                     set_orientation: gtk::Orientation::Vertical,
@@ -372,6 +368,7 @@ impl AsyncComponent for AppModel {
                     set_halign: gtk::Align::Center,
 
                     gtk::Spinner {
+                        add_css_class: "bootstrap-spinner-large",
                         start: (),
                     }
                 }

--- a/lact-gui/src/app/gpu_selector.rs
+++ b/lact-gui/src/app/gpu_selector.rs
@@ -1,10 +1,7 @@
-use crate::CONFIG;
 use gtk::glib;
 use gtk::prelude::*;
 use lact_client::schema::DeviceListEntry;
-use lact_schema::DeviceType;
 use relm4::{ComponentParts, ComponentSender, RelmWidgetExt, SimpleComponent, WidgetTemplate, css};
-use tracing::debug;
 
 pub struct GpuSelector {
     devices: Vec<DeviceListEntry>,
@@ -12,9 +9,9 @@ pub struct GpuSelector {
 
 #[relm4::component(pub)]
 impl SimpleComponent for GpuSelector {
-    type Init = Vec<DeviceListEntry>;
+    type Init = (Vec<DeviceListEntry>, Option<String>);
     type Input = ();
-    type Output = u32;
+    type Output = String;
 
     view! {
         gtk::Box {
@@ -38,21 +35,25 @@ impl SimpleComponent for GpuSelector {
     }
 
     fn init(
-        devices: Self::Init,
+        (devices, selected_gpu_id): Self::Init,
         _root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let model = Self { devices };
         let widgets = view_output!();
 
-        let (button_factory, list_factory, string_list, selected_index) =
-            Self::build_factories(&model.devices);
+        let (button_factory, list_factory, string_list) = Self::build_factories(&model.devices);
         widgets.dropdown.set_model(Some(&string_list));
         widgets.dropdown.set_factory(Some(&button_factory));
         widgets.dropdown.set_list_factory(Some(&list_factory));
-        widgets.dropdown.set_selected(selected_index);
-
-        Self::select_gpu(&model.devices, selected_index, &sender);
+        if let Some(selected_gpu_id) = selected_gpu_id
+            && let Some(index) = model
+                .devices
+                .iter()
+                .position(|device| device.id == selected_gpu_id)
+        {
+            widgets.dropdown.set_selected(index as u32);
+        }
 
         let devices_vec = model.devices.clone();
         let sender_clone = sender.clone();
@@ -71,33 +72,12 @@ impl GpuSelector {
         gtk::SignalListItemFactory,
         gtk::SignalListItemFactory,
         gtk::StringList,
-        u32,
     ) {
         let devices_vec = devices.to_vec();
         let string_list = gtk::StringList::new(&[]);
         for device in &devices_vec {
             string_list.append(&device.to_string());
         }
-
-        let selected_index = CONFIG
-            .read()
-            .selected_gpu
-            .as_ref()
-            .and_then(|selected_gpu_id| {
-                devices_vec
-                    .iter()
-                    .position(|device| device.id == *selected_gpu_id)
-                    .inspect(|_| debug!("selecting gpu id {selected_gpu_id}"))
-            })
-            .or_else(|| {
-                devices_vec
-                    .iter()
-                    .position(|device| device.device_type == DeviceType::Dedicated)
-                    .inspect(|index| {
-                        debug!("selecting default dedicated gpu {}", devices_vec[*index].id)
-                    })
-            })
-            .unwrap_or(0) as u32;
 
         let button_factory = gtk::SignalListItemFactory::new();
         button_factory.connect_setup(|_, list_item| {
@@ -156,17 +136,13 @@ impl GpuSelector {
             }
         ));
 
-        (button_factory, list_factory, string_list, selected_index)
+        (button_factory, list_factory, string_list)
     }
 
     fn select_gpu(devices: &[DeviceListEntry], selected: u32, sender: &ComponentSender<Self>) {
-        let id = devices
-            .get(selected as usize)
-            .map(|device| device.id.clone());
-        CONFIG.write().edit(|config| {
-            config.selected_gpu = id;
-        });
-        sender.output(selected).unwrap()
+        if let Some(device) = devices.get(selected as usize) {
+            sender.output(device.id.clone()).unwrap();
+        }
     }
 }
 

--- a/lact-gui/src/app/gpu_selector.rs
+++ b/lact-gui/src/app/gpu_selector.rs
@@ -1,6 +1,6 @@
 use gtk::glib;
 use gtk::prelude::*;
-use lact_client::schema::DeviceListEntry;
+use lact_schema::DeviceListEntry;
 use relm4::{ComponentParts, ComponentSender, RelmWidgetExt, SimpleComponent, WidgetTemplate, css};
 
 pub struct GpuSelector {

--- a/lact-gui/src/app/msg.rs
+++ b/lact-gui/src/app/msg.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub enum AppMsg {
     Error(Arc<anyhow::Error>),
-    GpuSelected(u32),
+    SelectGpu(String),
     ReloadData {
         full: bool,
     },

--- a/lact-gui/src/app/msg.rs
+++ b/lact-gui/src/app/msg.rs
@@ -2,7 +2,9 @@ use super::profiles::profile_rule_window::{
     ProfileRuleWindowMsg, profile_rule_row::ProfileRuleRowMsg,
 };
 use lact_client::ConnectionStatusMsg;
-use lact_schema::{DeviceStats, ProfileRule, config::ProfileHooks, request::ProfileBase};
+use lact_schema::{
+    DeviceStats, ProfileRule, ProfilesInfo, config::ProfileHooks, request::ProfileBase,
+};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -13,6 +15,7 @@ pub enum AppMsg {
         full: bool,
     },
     Stats(Arc<DeviceStats>),
+    ProfilesPolled(Arc<ProfilesInfo>),
     ApplyChanges,
     RevertChanges,
     SettingsChanged,

--- a/lact-gui/src/app/profiles.rs
+++ b/lact-gui/src/app/profiles.rs
@@ -330,7 +330,10 @@ impl ProfileSelector {
         }
         debug!("setting new profiles info: {profiles_info:?}");
 
-        sender.output(AppMsg::ReloadData { full: false }).unwrap();
+        let initial_load = self.profile_selector.is_empty();
+        if !initial_load {
+            sender.output(AppMsg::ReloadData { full: false }).unwrap();
+        }
 
         let mut profiles = self.profile_selector.guard();
         profiles.clear();

--- a/lact-gui/src/app/profiles.rs
+++ b/lact-gui/src/app/profiles.rs
@@ -22,10 +22,11 @@ use relm4::css;
 use relm4::prelude::DynamicIndex;
 use relm4::prelude::FactoryVecDeque;
 use relm4::{ComponentParts, ComponentSender};
+use std::sync::Arc;
 use tracing::debug;
 
 pub struct ProfileSelector {
-    profiles_info: ProfilesInfo,
+    profiles_info: Arc<ProfilesInfo>,
     profile_selector: FactoryVecDeque<ProfileRow>,
 
     new_profile_diag: Option<relm4::Controller<NewProfileDialog>>,
@@ -34,7 +35,7 @@ pub struct ProfileSelector {
 #[derive(Debug)]
 pub enum ProfileSelectorMsg {
     ClosePopover,
-    Profiles(Box<ProfilesInfo>),
+    Profiles(Arc<ProfilesInfo>),
     AutoProfileSwitch(bool),
     ShowProfileEditor(DynamicIndex),
     ExportProfile(DynamicIndex),
@@ -154,7 +155,7 @@ impl Component for ProfileSelector {
         ));
 
         let model = Self {
-            profiles_info: ProfilesInfo::default(),
+            profiles_info: Arc::new(ProfilesInfo::default()),
             profile_selector,
             new_profile_diag: None,
         };
@@ -193,7 +194,7 @@ impl Component for ProfileSelector {
                 widgets.root_menubutton.popdown();
             }
             ProfileSelectorMsg::Profiles(profiles_info) => {
-                self.set_profiles_info(&sender, *profiles_info)
+                self.set_profiles_info(profiles_info);
             }
             ProfileSelectorMsg::AutoProfileSwitch(auto_switch) => {
                 let msg = AppMsg::SelectProfile {
@@ -324,16 +325,17 @@ impl ProfileSelector {
         self.profiles_info.auto_switch
     }
 
-    fn set_profiles_info(&mut self, sender: &ComponentSender<Self>, profiles_info: ProfilesInfo) {
-        if self.profiles_info == profiles_info && !self.profile_selector.is_empty() {
+    pub fn profiles_info_changed(&self, profiles_info: &ProfilesInfo) -> bool {
+        self.profiles_info.as_ref() != profiles_info
+    }
+
+    fn set_profiles_info(&mut self, profiles_info: Arc<ProfilesInfo>) {
+        if self.profiles_info.as_ref() == profiles_info.as_ref()
+            && !self.profile_selector.is_empty()
+        {
             return;
         }
         debug!("setting new profiles info: {profiles_info:?}");
-
-        let initial_load = self.profile_selector.is_empty();
-        if !initial_load {
-            sender.output(AppMsg::ReloadData { full: false }).unwrap();
-        }
 
         let mut profiles = self.profile_selector.guard();
         profiles.clear();


### PR DESCRIPTION
before the change there were 3 reloads during bootstrap.
The old bootstrap path had:
- `ReloadProfiles`
- `GpuSelected`
- profile selector emitting `ReloadData { full: false }`
- then `ReloadData { full: true }`
- then another `ReloadData { full: false }

I also slightly refactored set_profile_data, by removing reload side effect