### PR TITLE
feat: rework app menu using actions; add keyboard shortcuts for preferences and quit

### DIFF
--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -196,6 +196,7 @@ vram-pstates = VRAM Power States
 pstates-manual-needed = Performance level must be set to 'manual' to toggle power states
 enable-pstate-config = Enable power state configuration
 
+menu = Menu
 show-historical-charts = Show Graphs
 show-process-monitor = Show Process Monitor
 generate-debug-snapshot = Generate Debug Snapshot

--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -62,9 +62,11 @@ use pages::{
 use relm4::{
     AsyncComponentSender, Component, ComponentController, MessageBroker, RelmObjectExt,
     RelmWidgetExt,
+    actions::{AccelsPlus, ActionGroupName, RelmAction, RelmActionGroup},
     binding::BoolBinding,
     css,
     loading_widgets::LoadingWidgets,
+    new_action_group, new_stateless_action,
     prelude::{AsyncComponent, AsyncComponentParts},
     tokio::{self, time::sleep},
     view,
@@ -87,6 +89,14 @@ const DEFAULT_WINDOW_WIDTH: i32 = 1100;
 const DEFAULT_WINDOW_HEIGHT: i32 = 750;
 const CONFIRM_RESPONSE_APPLY: &str = "confirm";
 const CONFIRM_RESPONSE_REVERT: &str = "revert";
+
+macro_rules! setup_actions {
+    ($(($grp:ident, $action:ty, $callback:expr),)*) => {
+        $(
+            $grp.add_action(RelmAction::<$action>::new_stateless(move |_| $callback));
+        )*
+    };
+}
 
 pub struct AppModel {
     daemon_client: DaemonClient,
@@ -114,6 +124,10 @@ pub struct AppModel {
     system_info: SystemInfo,
     device_flags: Vec<DeviceFlag>,
     device_driver: String,
+
+    application: gtk::Application,
+
+    dump_vbios_action: gtk::gio::SimpleAction,
 }
 
 #[derive(Debug)]
@@ -129,6 +143,22 @@ impl AsyncComponent for AppModel {
     type Input = AppMsg;
     type Output = ();
     type CommandOutput = Option<CommandOutput>;
+
+    menu! {
+        app_menu: {
+            section! {
+                &fl!(I18N, "show-process-monitor") => ProcessMonitorAction,
+            },
+            section! {
+                &fl!(I18N, "generate-debug-snapshot") => GenerateDebugSnapshotAction,
+                &fl!(I18N, "dump-vbios") => DumpVBiosAction,
+            },
+            section! {
+                &fl!(I18N, "preferences") => PreferencesAction,
+                &fl!(I18N, "about") => AboutAction,
+            },
+        }
+    }
 
     view! {
         #[root]
@@ -218,67 +248,8 @@ impl AsyncComponent for AppModel {
 
                                     pack_end = &gtk::MenuButton {
                                         set_icon_name: "open-menu-symbolic",
-
-                                        #[wrap(Some)]
-                                        #[name = "header_menu_popover"]
-                                        set_popover = &gtk::Popover {
-
-                                            gtk::Box {
-                                                set_orientation: gtk::Orientation::Vertical,
-                                                add_css_class: "header-settings-popover-container",
-
-                                                gtk::Button {
-                                                    set_label: &fl!(I18N, "show-process-monitor"),
-                                                    connect_clicked[header_menu_popover] => move |_| {
-                                                        header_menu_popover.popdown();
-                                                        APP_BROKER.send(AppMsg::ShowProcessMonitor);
-                                                    },
-                                                    add_css_class: "flat",
-                                                },
-
-                                                gtk::Separator {},
-
-                                                gtk::Button {
-                                                    set_label: &fl!(I18N, "generate-debug-snapshot"),
-                                                    connect_clicked[header_menu_popover] => move |_| {
-                                                        header_menu_popover.popdown();
-                                                        APP_BROKER.send(AppMsg::DebugSnapshot);
-                                                    },
-                                                    add_css_class: "flat",
-                                                },
-
-                                                gtk::Button {
-                                                    set_label: &fl!(I18N, "dump-vbios"),
-                                                    connect_clicked[header_menu_popover] => move |_| {
-                                                        header_menu_popover.popdown();
-                                                        APP_BROKER.send(AppMsg::DumpVBios);
-                                                    },
-                                                    add_css_class: "flat",
-                                                    #[watch]
-                                                    set_sensitive: model.device_flags.contains(&DeviceFlag::DumpableVBios),
-                                                },
-
-                                                gtk::Separator {},
-
-                                                gtk::Button {
-                                                    set_label: &fl!(I18N, "preferences"),
-                                                    connect_clicked[header_menu_popover] => move |_| {
-                                                        header_menu_popover.popdown();
-                                                        APP_BROKER.send(AppMsg::ShowPreferencesDialog);
-                                                    },
-                                                    add_css_class: "flat",
-                                                },
-
-                                                gtk::Button {
-                                                    set_label: &fl!(I18N, "about"),
-                                                    connect_clicked[header_menu_popover] => move |_| {
-                                                        header_menu_popover.popdown();
-                                                        APP_BROKER.send(AppMsg::ShowAboutDialog);
-                                                    },
-                                                    add_css_class: "flat",
-                                                },
-                                            }
-                                        },
+                                        set_tooltip_text: Some(&fl!(I18N, "menu")),
+                                        set_menu_model: Some(&app_menu),
                                     },
 
                                     pack_end = &gtk::Button {
@@ -500,6 +471,34 @@ impl AsyncComponent for AppModel {
             .launch(())
             .forward(sender.input_sender(), |msg| msg);
 
+        // create action group and actions for app menu
+        // action group and actions are declared at the bottom of the file
+        let mut actions = RelmActionGroup::<AppActionGroup>::new();
+        let application = root
+            .application()
+            .expect("Failed to get application from root window");
+        setup_actions! {
+            (actions, ProcessMonitorAction, APP_BROKER.send(AppMsg::ShowProcessMonitor)),
+            (actions, GenerateDebugSnapshotAction, APP_BROKER.send(AppMsg::DebugSnapshot)),
+            (actions, PreferencesAction, APP_BROKER.send(AppMsg::ShowPreferencesDialog)),
+            (actions, AboutAction, APP_BROKER.send(AppMsg::ShowAboutDialog)),
+            (actions, QuitAction, APP_BROKER.send(AppMsg::Quit)),
+        }
+        // this action is enabled/disabled conditionally in [Self::update_gpu_data_full]
+        // when the device flags are set, only if the device contains the DumpableVBios flag
+        let dump_vbios_action = {
+            let action = RelmAction::<DumpVBiosAction>::new_stateless(move |_| {
+                APP_BROKER.send(AppMsg::DumpVBios);
+            });
+            let gio_action = action.gio_action().clone();
+            actions.add_action(action);
+            gio_action.set_enabled(false);
+            gio_action
+        };
+        application.set_accelerators_for_action::<PreferencesAction>(&["<Control>comma"]);
+        application.set_accelerators_for_action::<QuitAction>(&["<Control>q"]);
+        root.insert_action_group(AppActionGroup::NAME, Some(&actions.into_action_group()));
+
         let mut model = AppModel {
             daemon_client,
             graphs_window,
@@ -521,6 +520,8 @@ impl AsyncComponent for AppModel {
             system_info,
             device_flags: vec![],
             device_driver: String::new(),
+            dump_vbios_action,
+            application,
         };
 
         if let Err(err) = model.reload_profiles(None).await {
@@ -918,6 +919,9 @@ impl AppModel {
                     handle.abort();
                 }
             }
+            AppMsg::Quit => {
+                self.application.quit();
+            }
         }
         Ok(())
     }
@@ -1035,6 +1039,8 @@ impl AppModel {
         }
 
         self.device_flags = info.flags.clone();
+        self.dump_vbios_action
+            .set_enabled(self.device_flags.contains(&DeviceFlag::DumpableVBios));
         self.device_driver = info.driver.clone();
 
         let update = PageUpdate::Info(info.clone());
@@ -1419,3 +1425,11 @@ async fn create_connection() -> anyhow::Result<(DaemonClient, Option<anyhow::Err
         }
     }
 }
+
+new_action_group!(pub AppActionGroup, "app");
+new_stateless_action!(pub ProcessMonitorAction, AppActionGroup, "show-process-monitor");
+new_stateless_action!(pub GenerateDebugSnapshotAction, AppActionGroup, "generate-debug-snapshot");
+new_stateless_action!(pub DumpVBiosAction, AppActionGroup, "dump-vbios");
+new_stateless_action!(pub PreferencesAction, AppActionGroup, "preferences");
+new_stateless_action!(pub AboutAction, AppActionGroup, "about");
+new_stateless_action!(pub QuitAction, AppActionGroup, "quit");

--- a/lact-gui/src/app/msg.rs
+++ b/lact-gui/src/app/msg.rs
@@ -54,4 +54,5 @@ pub enum AppMsg {
     ExportProfile(Option<String>),
     ConnectionStatus(ConnectionStatusMsg),
     Crash(String),
+    Quit,
 }


### PR DESCRIPTION
As per the title. Here's a comparison between the old implementation using buttons and the new one:


| master | rework-menu |
|---|---|
| ![](https://github.com/user-attachments/assets/8532f275-e0e1-47d8-a1bf-fa151cbe0064) | ![](https://github.com/user-attachments/assets/20c13155-5400-407c-9602-8c0cc928248b) |

Other notable changes include:

- Added tooltip to the menu button
- "Quit" action, mostly to bind it to Ctrl+Q as in most other apps
- "Preferences" action bound to Ctrl+comma, again conforming with most other apps
- The dump_vbios_action is in the application state, that's because it's enabled/disabled when gathering the device flags, so I need a way to keep a reference to it around, and this was probably the simplest way
- The application variable contains a reference to adw::Application (subclass of gtk::Application and I believe gio::Application as well), this is used to call its quit method when handling the newly introduced quit message. If you don't think this approach is good enough it's also possible to call root.application(), but that returns an option that needs to be unwrapped somehow. It's safe to do it in the context where it's ran, but I'd rather have it done just once.