### PR TITLE
fix: missing fan curve options on nvidia

### DIFF
--- a/lact-gui/src/app/pages/thermals_page.rs
+++ b/lact-gui/src/app/pages/thermals_page.rs
@@ -467,6 +467,7 @@ impl relm4::Component for ThermalsPage {
 
                         let msg = CurveSetupMsg {
                             curve: stats.fan.curve.clone().unwrap_or_else(default_fan_curve),
+                            hw_based: self.has_pmfw,
                             current_temperatures: stats.temps.clone(),
                             temperature_key: stats.fan.temperature_key.clone(),
                             spindown_delay: stats.fan.spindown_delay_ms,

--- a/lact-gui/src/app/pages/thermals_page/fan_curve_frame.rs
+++ b/lact-gui/src/app/pages/thermals_page/fan_curve_frame.rs
@@ -51,6 +51,8 @@ const PERCENTAGE_DRAG_MARGIN: f32 = 0.04;
 #[derive(Clone)]
 pub(super) struct FanCurveFrame {
     pmfw_options: PmfwOptions,
+    /// PMFW fan control on AMD RDNA3+ with fixed length
+    hw_based_fan_curve: Rc<AtomicBool>,
 
     data: Rc<RefCell<Vec<(i32, f32)>>>,
     speed_range: Rc<RefCell<RangeInclusive<f32>>>,
@@ -89,6 +91,7 @@ pub(super) enum FanCurveFrameMsg {
 #[derive(Debug)]
 pub(super) struct CurveSetupMsg {
     pub curve: FanCurveMap,
+    pub hw_based: bool,
     pub current_temperatures: HashMap<String, TemperatureEntry>,
     pub temperature_key: Option<String>,
     pub speed_range: RangeInclusive<f32>,
@@ -156,14 +159,14 @@ impl relm4::Component for FanCurveFrame {
                     set_icon_name: "list-add-symbolic",
                     connect_clicked => FanCurveFrameMsg::AddPoint,
                     #[watch]
-                    set_visible: model.pmfw_options.is_empty(),
+                    set_visible: !model.hw_based_fan_curve.load(Ordering::SeqCst),
                 },
 
                 gtk::Button {
                     set_icon_name: "list-remove-symbolic",
                     connect_clicked => FanCurveFrameMsg::RemovePoint,
                     #[watch]
-                    set_visible: model.pmfw_options.is_empty(),
+                    set_visible: !model.hw_based_fan_curve.load(Ordering::SeqCst),
                 },
 
                 gtk::Button {
@@ -196,7 +199,7 @@ impl relm4::Component for FanCurveFrame {
             #[template]
             FanSettingRow {
                 #[watch]
-                set_visible: model.pmfw_options.is_empty(),
+                set_visible: !model.hw_based_fan_curve.load(Ordering::SeqCst),
 
                 #[template_child]
                 label {
@@ -220,7 +223,7 @@ impl relm4::Component for FanCurveFrame {
             #[template]
             FanSettingRow {
                 #[watch]
-                set_visible: model.pmfw_options.is_empty(),
+                set_visible: !model.hw_based_fan_curve.load(Ordering::SeqCst),
 
                 #[template_child]
                 label {
@@ -329,6 +332,7 @@ impl relm4::Component for FanCurveFrame {
 
         let mut model = Self {
             pmfw_options,
+            hw_based_fan_curve: Rc::new(AtomicBool::new(false)),
             is_dragging: Rc::new(AtomicBool::new(false)),
             speed_range: Rc::new(RefCell::new(DEFAULT_SPEED_RANGE)),
             temperature_range: Rc::new(RefCell::new(DEFAULT_TEMP_RANGE)),
@@ -387,6 +391,8 @@ impl relm4::Component for FanCurveFrame {
                         .collect();
                 *self.speed_range.borrow_mut() = msg.speed_range;
                 *self.temperature_range.borrow_mut() = msg.temperature_range.clone();
+                self.hw_based_fan_curve
+                    .store(msg.hw_based, Ordering::SeqCst);
 
                 for (adj, signal) in self.change_signals.iter() {
                     adj.block_signal(signal);
@@ -530,7 +536,7 @@ impl FanCurveFrame {
     }
 
     fn temp_keys_available(&self) -> bool {
-        self.pmfw_options.is_empty()
+        !self.hw_based_fan_curve.load(Ordering::SeqCst)
             && self.temp_keys.n_items() > 1
             && (self.auto_threshold_adj.upper() == 0.0) // Disable key selection on nvidia
     }


### PR DESCRIPTION
Fixes https://github.com/ilya-zlobintsev/LACT/issues/1033

This was regressed in https://github.com/ilya-zlobintsev/LACT/pull/917 since having pmfw options present made the curve assume the curve is static-length like on AMD cards with pmfw.