### PR TITLE
feat: use banner instead of dialog to signal daemon reconnection

### DIFF
--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -65,7 +65,7 @@ use relm4::{
     AsyncComponentSender, Component, ComponentController, MessageBroker, RelmObjectExt,
     RelmWidgetExt,
     actions::{AccelsPlus, ActionGroupName, RelmAction, RelmActionGroup},
-    binding::BoolBinding,
+    binding::{Binding as _, BoolBinding},
     css,
     loading_widgets::LoadingWidgets,
     new_action_group, new_stateless_action,
@@ -110,6 +110,7 @@ pub struct AppModel {
     info_dialog: relm4::Controller<InfoDialog>,
 
     ui_sensitive: BoolBinding,
+    is_reconnecting: BoolBinding,
 
     info_page: relm4::Controller<InformationPage>,
     oc_page: relm4::Controller<OcPage>,
@@ -198,6 +199,7 @@ impl AsyncComponent for AppModel {
                                     set_orientation: gtk::Orientation::Vertical,
                                     set_vexpand: true,
                                     add_css_class: "main-sidebar-container",
+                                    add_binding: (&model.ui_sensitive, "sensitive"),
 
                                     model.gpu_selector.widget().clone() {},
 
@@ -247,16 +249,17 @@ impl AsyncComponent for AppModel {
                             set_child = &adw::ToolbarView {
                                 #[name = "content_header"]
                                 add_top_bar = &adw::HeaderBar {
-
                                     pack_end = &gtk::MenuButton {
                                         set_icon_name: "open-menu-symbolic",
                                         set_tooltip_text: Some(&fl!(I18N, "menu")),
                                         set_menu_model: Some(&app_menu),
+                                        add_binding: (&model.ui_sensitive, "sensitive"),
                                     },
 
                                     pack_end = &gtk::Button {
                                         set_label: &fl!(I18N, "show-historical-charts"),
                                         connect_clicked => move |_| APP_BROKER.send(AppMsg::ShowGraphsWindow),
+                                        add_binding: (&model.ui_sensitive, "sensitive"),
                                     },
                                 },
 
@@ -268,6 +271,11 @@ impl AsyncComponent for AppModel {
                                     set_button_label: Some(&fl!(I18N, "enable-amd-oc")),
 
                                     connect_button_clicked => AppMsg::ShowOverdriveDialog,
+                                },
+
+                                add_top_bar = &adw::Banner {
+                                    set_title: &fl!(I18N, "reconnecting-to-daemon"),
+                                    add_binding: (&model.is_reconnecting, "revealed"),
                                 },
 
                                 #[wrap(Some)]
@@ -314,20 +322,6 @@ impl AsyncComponent for AppModel {
                 }
                 }
             },
-
-        #[name = "reconnecting_dialog"]
-        adw::Dialog {
-            set_title: &fl!(I18N, "daemon-connection-lost"),
-            set_content_width: 300,
-            set_content_height: 80,
-            set_can_close: false,
-
-            #[wrap(Some)]
-            set_child = &gtk::Label {
-                set_margin_all: 10,
-                set_label: &fl!(I18N, "reconnecting-to-daemon"),
-            }
-        },
     }
 
     fn init_loading_widgets(root: Self::Root) -> Option<LoadingWidgets> {
@@ -509,6 +503,7 @@ impl AsyncComponent for AppModel {
             gpu_selector,
             profile_selector,
             ui_sensitive: BoolBinding::new(false),
+            is_reconnecting: BoolBinding::new(false),
             stats_task_handle: None,
             settings_changed,
             system_info,
@@ -877,9 +872,13 @@ impl AppModel {
             }
             AppMsg::ConnectionStatus(status) => match status {
                 ConnectionStatusMsg::Disconnected => {
-                    widgets.reconnecting_dialog.present(Some(root))
+                    self.ui_sensitive.set(false);
+                    self.is_reconnecting.set(true);
                 }
-                ConnectionStatusMsg::Reconnected => widgets.reconnecting_dialog.force_close(),
+                ConnectionStatusMsg::Reconnected => {
+                    self.ui_sensitive.set(true);
+                    self.is_reconnecting.set(false);
+                }
             },
             AppMsg::EvaluateProfile(rule, sender) => {
                 match self.daemon_client.evaluate_profile_rule(rule).await {


### PR DESCRIPTION
This looks a bit nicer, and has a side effect of making things easier for #1043

<img width="1088" height="470" alt="image" src="https://github.com/user-attachments/assets/1881994d-9087-4173-8ffa-0f061216b1ad" />
