### PR TITLE
chore: use tokio local runtime instead of LocalSet

### DIFF
--- a/lact-daemon/src/lib.rs
+++ b/lact-daemon/src/lib.rs
@@ -17,12 +17,12 @@ use server::{Server, handle_stream, handler::Handler};
 use std::sync::Arc;
 use std::{os::unix::net::UnixStream as StdUnixStream, time::Duration};
 use tokio::net::UnixStream;
+use tokio::runtime::LocalOptions;
 use tokio::sync::Notify;
 use tokio::time::timeout;
 use tokio::{
     runtime,
     signal::unix::{SignalKind, signal},
-    task::LocalSet,
 };
 use tracing::level_filters::LevelFilter;
 use tracing::{Instrument, debug, debug_span, error, info, warn};
@@ -46,7 +46,7 @@ const SHUTDOWN_SIGNALS: [SignalKind; 4] = [
 pub fn run() -> anyhow::Result<()> {
     let rt = runtime::Builder::new_current_thread()
         .enable_all()
-        .build()
+        .build_local(LocalOptions::default())
         .expect("Could not initialize tokio runtime");
     rt.block_on(async {
         let config = Config::load_or_create()?;
@@ -59,20 +59,16 @@ pub fn run() -> anyhow::Result<()> {
 
         ensure_sufficient_uptime().await;
 
-        LocalSet::new()
-            .run_until(async move {
-                let server = Server::new(config).await?;
-                let handler = server.handler.clone();
+        let server = Server::new(config).await?;
+        let handler = server.handler.clone();
 
-                tokio::task::spawn_local(listen_config_changes(handler.clone()));
-                tokio::task::spawn_local(listen_exit_signals(handler.clone()));
-                tokio::task::spawn_local(listen_device_events(handler.clone()));
-                tokio::task::spawn_local(suspend::listen_events(handler));
+        tokio::task::spawn_local(listen_config_changes(handler.clone()));
+        tokio::task::spawn_local(listen_exit_signals(handler.clone()));
+        tokio::task::spawn_local(listen_device_events(handler.clone()));
+        tokio::task::spawn_local(suspend::listen_events(handler));
 
-                server.run().await;
-                Ok(())
-            })
-            .await
+        server.run().await;
+        Ok(())
     })
 }
 
@@ -84,18 +80,14 @@ pub fn run() -> anyhow::Result<()> {
 pub fn run_embedded(stream: StdUnixStream) -> anyhow::Result<()> {
     let rt = runtime::Builder::new_current_thread()
         .enable_all()
-        .build()
+        .build_local(LocalOptions::default())
         .expect("Could not initialize tokio runtime");
     rt.block_on(async {
-        LocalSet::new()
-            .run_until(async move {
-                let config = Config::default();
-                let handler = Handler::new(config).await?;
-                let stream = UnixStream::try_from(stream)?;
+        let config = Config::default();
+        let handler = Handler::new(config).await?;
+        let stream = UnixStream::try_from(stream)?;
 
-                handle_stream(stream, handler).await
-            })
-            .await
+        handle_stream(stream, handler).await
     })
 }
 

--- a/lact-daemon/src/tests/mod.rs
+++ b/lact-daemon/src/tests/mod.rs
@@ -9,7 +9,6 @@ use lact_schema::config::GpuConfig;
 use mock_fs::MockSysfs;
 use std::{fs, path::PathBuf, sync::OnceLock};
 use tempfile::tempdir;
-use tokio::task::LocalSet;
 
 fn init_tracing() {
     static TRACING_LOCK: OnceLock<()> = OnceLock::new();
@@ -55,78 +54,70 @@ async fn snapshot_everything() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "local")]
 #[cfg_attr(miri, ignore)]
 async fn apply_settings() {
     init_tracing();
 
-    let local_set = LocalSet::new();
-    local_set.spawn_local(async move {
-        let test_data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../tests/snapshots");
-        let pci_db = read_pci_db();
+    let test_data_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../tests/snapshots");
+    let pci_db = read_pci_db();
 
-        for vendor_dir in fs::read_dir(test_data_dir).unwrap().flatten() {
-            if !vendor_dir.metadata().unwrap().is_dir() {
-                continue;
-            }
+    for vendor_dir in fs::read_dir(test_data_dir).unwrap().flatten() {
+        if !vendor_dir.metadata().unwrap().is_dir() {
+            continue;
+        }
 
-            for device_dir in fs::read_dir(vendor_dir.path()).unwrap().flatten() {
-                for entry in fs::read_dir(device_dir.path()).unwrap().flatten() {
-                    let name = entry.file_name();
-                    let name = name.to_str().unwrap();
+        for device_dir in fs::read_dir(vendor_dir.path()).unwrap().flatten() {
+            for entry in fs::read_dir(device_dir.path()).unwrap().flatten() {
+                let name = entry.file_name();
+                let name = name.to_str().unwrap();
 
-                    #[allow(clippy::case_sensitive_file_extension_comparisons)]
-                    if name.starts_with("config") && name.ends_with(".yaml") {
-                        let test_key = format!(
-                            "apply_config/{}/{}/{name}",
-                            vendor_dir.file_name().to_string_lossy(),
-                            device_dir.file_name().to_string_lossy()
-                        );
-                        let raw_gpu_config = fs::read_to_string(entry.path()).unwrap();
-                        let gpu_config: GpuConfig =
-                            serde_norway::from_str(&raw_gpu_config).unwrap();
+                #[allow(clippy::case_sensitive_file_extension_comparisons)]
+                if name.starts_with("config") && name.ends_with(".yaml") {
+                    let test_key = format!(
+                        "apply_config/{}/{}/{name}",
+                        vendor_dir.file_name().to_string_lossy(),
+                        device_dir.file_name().to_string_lossy()
+                    );
+                    let raw_gpu_config = fs::read_to_string(entry.path()).unwrap();
+                    let gpu_config: GpuConfig = serde_norway::from_str(&raw_gpu_config).unwrap();
 
-                        let mock_fs_dir = tempdir().unwrap();
+                    let mock_fs_dir = tempdir().unwrap();
 
-                        let mock_fs = MockSysfs::new(device_dir.path());
-                        let writes = mock_fs.writes.clone();
+                    let mock_fs = MockSysfs::new(device_dir.path());
+                    let writes = mock_fs.writes.clone();
 
-                        let mount = easy_fuser::spawn_mount(mock_fs, mock_fs_dir.path(), &[], 1)
-                            .expect("Could not mount mock fs");
+                    let mount = easy_fuser::spawn_mount(mock_fs, mock_fs_dir.path(), &[], 1)
+                        .expect("Could not mount mock fs");
 
-                        let handler =
-                            Handler::with_base_path(mock_fs_dir.path(), Config::default(), &pci_db)
-                                .await
-                                .unwrap();
-                        let gpu_id = &handler.list_devices().await[0].id;
-
-                        handler
-                            .config
-                            .write()
+                    let handler =
+                        Handler::with_base_path(mock_fs_dir.path(), Config::default(), &pci_db)
                             .await
-                            .gpus_mut()
-                            .unwrap()
-                            .insert(gpu_id.clone(), gpu_config);
+                            .unwrap();
+                    let gpu_id = &handler.list_devices().await[0].id;
 
-                        handler.apply_current_config().await.unwrap();
+                    handler
+                        .config
+                        .write()
+                        .await
+                        .gpus_mut()
+                        .unwrap()
+                        .insert(gpu_id.clone(), gpu_config);
 
-                        mount.join();
-                        mock_fs_dir.close().unwrap();
+                    handler.apply_current_config().await.unwrap();
 
-                        let write_commands = writes
-                            .lock()
-                            .unwrap()
-                            .iter()
-                            .map(|(name, contents)| {
-                                format!("{}: {contents}", name.to_str().unwrap())
-                            })
-                            .collect::<Vec<String>>();
-                        assert_debug_snapshot!(test_key, write_commands);
-                    }
+                    mount.join();
+                    mock_fs_dir.close().unwrap();
+
+                    let write_commands = writes
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .map(|(name, contents)| format!("{}: {contents}", name.to_str().unwrap()))
+                        .collect::<Vec<String>>();
+                    assert_debug_snapshot!(test_key, write_commands);
                 }
             }
         }
-    });
-
-    local_set.await;
+    }
 }


### PR DESCRIPTION
Apparently this is a thing now, and `LocalSet` is not really needed