### PR TITLE
fix: correct nvidia fan curve pwm to percent conversion

### DIFF
--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -280,7 +280,7 @@ impl NvidiaGpuController {
                 for fan in 0..fan_count {
                     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                     if let Err(err) =
-                        device.set_fan_speed(fan, (f64::from(target_pwm) / 2.5) as u32)
+                        device.set_fan_speed(fan, (f64::from(target_pwm) / 2.55) as u32)
                     {
                         error!("could not set fan speed: {err}, disabling fan control");
                         break;


### PR DESCRIPTION
The curve control loop converted PWM (0-255) to the percentage NVML expects with `/ 2.5`, mapping a 255 PWM to 102% - outside the valid 0-100 range. A curve top point of 1.0 was therefore rejected with INVALID_ARGUMENT, after which the daemon disabled fan control for the GPU. 

The divisor should be 2.55 - the inverse of the `* 2.55` percent-to-pwm conversion already used in this file (255 / 2.55 = 100).