### PR TITLE
fix: libdisplay-info dependency on debian-based systems

### DIFF
--- a/pkg/recipes/lact/recipe.yml
+++ b/pkg/recipes/lact/recipe.yml
@@ -12,7 +12,10 @@ metadata:
   conflicts: [ lact-headless ]
   depends:
     all: [ hwdata, vulkan-tools, clinfo ]
-    debian-13+ubuntu-2404+ubuntu-2604: [ libgtk-4-1, libdrm2, libdrm-amdgpu1, libadwaita-1-0, libdisplay-info ]
+    debian-13+ubuntu-2404+ubuntu-2604: [ libgtk-4-1, libdrm2, libdrm-amdgpu1, libadwaita-1-0 ]
+    debian-13: [ libdisplay-info2 ]
+    ubuntu-2404: [ libdisplay-info1 ]
+    ubuntu-2604: [ libdisplay-info3 ]
     fedora-43+fedora-44: [ gtk4, libdrm, libadwaita, libdisplay-info ]
     arch: [ gtk4, ocl-icd, libadwaita, libdisplay-info ]
     opensuse-tumbleweed: [ gtk4, libadwaita-1-0, libdisplay-info ]


### PR DESCRIPTION
Fixes #1075