### PR TITLE
fix: raise main window for apply confirmation

### DIFF
--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -1230,6 +1230,8 @@ impl AppModel {
 
         sender.input(AppMsg::ReloadData { full: false });
 
+        root.present();
+
         Ok(())
     }
 


### PR DESCRIPTION
Raises the main window when asking for settings confirmation. This was a regression from #997.