### PR TITLE
fix: automatically clamp power cap to the allowed range on AMD instead of relying on driver rejection

### DIFF
--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -1350,9 +1350,24 @@ impl GpuController for AmdGpuController {
             if let Some(configured_cap) = config.power_cap {
                 let hw_mon = self.first_hw_mon()?;
 
-                hw_mon
-                    .set_power_cap(configured_cap)
-                    .with_context(|| format!("Failed to set power cap: {configured_cap}"))?;
+                match (hw_mon.get_power_cap_min(), hw_mon.get_power_cap_max()) {
+                    (Ok(min), Ok(max)) => {
+                        let clamped_cap = configured_cap.clamp(min, max);
+
+                        if clamped_cap != configured_cap {
+                            warn!(
+                                "Power cap {configured_cap}W was outside of the allowed range, clamped to {clamped_cap}W"
+                            );
+                        }
+
+                        hw_mon.set_power_cap(clamped_cap).with_context(|| {
+                            format!("Failed to set power cap: {configured_cap}")
+                        })?;
+                    }
+                    (Err(err), _) | (_, Err(err)) => {
+                        bail!("Could not read allowed power cap range: {err:#}");
+                    }
+                }
             } else if let Ok(hw_mon) = self.first_hw_mon()
                 && let Ok(default_cap) = hw_mon.get_power_cap_default()
                 && Ok(default_cap) != hw_mon.get_power_cap()

--- a/lact-daemon/src/tests/snapshots/lact_daemon__tests__apply_config__amd__rx7900xtx__config.yaml.snap
+++ b/lact-daemon/src/tests/snapshots/lact_daemon__tests__apply_config__amd__rx7900xtx__config.yaml.snap
@@ -13,7 +13,7 @@ expression: write_commands
     "card0/device/gpu_od/fan_ctrl/fan_curve: 2 60 22\n",
     "card0/device/gpu_od/fan_ctrl/fan_curve: 3 70 29\n",
     "card0/device/gpu_od/fan_ctrl/fan_curve: 4 86 60\n",
-    "card0/device/hwmon/hwmon8/power1_cap: 245000000",
+    "card0/device/hwmon/hwmon8/power1_cap: 261000000",
     "card0/device/gpu_od/fan_ctrl/fan_curve: c\n",
     "card0/device/pp_od_clk_voltage: c\n",
 ]


### PR DESCRIPTION
This particularly helps in a scenario where the allowed power limit range changes because of something, see #1079 #1071