### PR TITLE
feat: QOL for displays info

### DIFF
--- a/lact-daemon/src/server/display.rs
+++ b/lact-daemon/src/server/display.rs
@@ -83,13 +83,13 @@ fn get_display_entry(path: &Path) -> anyhow::Result<(String, DisplayInfo)> {
         .0
     {
         "DP" => DisplayConnector::DisplayPort {
-            lanes: 0,
-            bandwidth: 0,
+            lanes: None,
+            bandwidth: None,
             embedded: false,
         },
         "eDP" => DisplayConnector::DisplayPort {
-            lanes: 0,
-            bandwidth: 0,
+            lanes: None,
+            bandwidth: None,
             embedded: true,
         },
         "HDMI" => DisplayConnector::Hdmi,

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -1451,11 +1451,13 @@ impl GpuController for AmdGpuController {
 
                 let mut parts = link_settings.split_ascii_whitespace().skip(1);
 
-                *lanes = parts
-                    .next()
-                    .context("Missing lane count")?
-                    .parse::<u16>()
-                    .context("Invalid lane count")?;
+                *lanes = Some(
+                    parts
+                        .next()
+                        .context("Missing lane count")?
+                        .parse::<u16>()
+                        .context("Invalid lane count")?,
+                );
 
                 let bw_enum = parts
                     .next()
@@ -1464,7 +1466,7 @@ impl GpuController for AmdGpuController {
                     .and_then(|value| u32::from_str_radix(value, 16).ok())
                     .context("Invalid bandwidth value")?;
 
-                *bandwidth = crate::server::display::dp_rate_to_bandwidth(bw_enum);
+                *bandwidth = Some(crate::server::display::dp_rate_to_bandwidth(bw_enum));
             }
         }
 

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -1331,9 +1331,10 @@ impl GpuController for NvidiaGpuController {
                         {
                             match handle.get_dp_link_config(display_id) {
                                 Ok(params) => {
-                                    *lanes = params.laneCount.try_into()?;
-                                    *bandwidth =
-                                        crate::server::display::dp_rate_to_bandwidth(params.linkBW);
+                                    *lanes = Some(params.laneCount.try_into()?);
+                                    *bandwidth = Some(
+                                        crate::server::display::dp_rate_to_bandwidth(params.linkBW),
+                                    );
                                 }
                                 Err(err) => {
                                     warn!("could not fetch DP info for display {key}: {err:#}");

--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -240,6 +240,7 @@ display-model = Model
 display-physical-size = Physical Size
 display-connection = Connection
 display-manufacture-date = Manufacture Date
+displays-missing = No Displays Detected
 
 settings-profile = Settings Profile
 auto-switch-profiles = Switch automatically

--- a/lact-gui/src/app/pages/displays_page.rs
+++ b/lact-gui/src/app/pages/displays_page.rs
@@ -26,6 +26,25 @@ impl relm4::SimpleComponent for DisplaysPage {
 
     view! {
         gtk::Box {
+            set_expand: true,
+            #[watch]
+            set_align: if model.displays.is_empty() { gtk::Align::Center } else { gtk::Align::Fill },
+            set_orientation: gtk::Orientation::Vertical,
+
+            gtk::Image {
+                set_icon_name: Some("action-unavailable-symbolic"),
+                set_align: gtk::Align::Center,
+                set_pixel_size: 64,
+                #[watch]
+                set_visible: model.displays.is_empty(),
+            },
+
+            gtk::Label {
+                set_markup: &format!("<b><span size='large'>{}</span></b>", fl!(I18N, "displays-missing")),
+                #[watch]
+                set_visible: model.displays.is_empty(),
+            },
+
             #[local_ref]
             displays_list -> gtk::Box {
                 set_orientation: gtk::Orientation::Vertical,

--- a/lact-gui/src/app/pages/displays_page.rs
+++ b/lact-gui/src/app/pages/displays_page.rs
@@ -175,13 +175,19 @@ impl DisplayComponent {
                 if embedded {
                     text.push_str(" (Internal)")
                 }
-                let lane_rate = bandwidth as f64 / 1000.0;
-                write!(
-                    text,
-                    " @ {} Gbps ({lane_rate} Gbps x {lanes} lanes)",
-                    lane_rate * lanes as f64
-                )
-                .unwrap();
+
+                if let Some(bandwidth) = bandwidth
+                    && let Some(lanes) = lanes
+                {
+                    let lane_rate = bandwidth as f64 / 1000.0;
+                    write!(
+                        text,
+                        " @ {} Gbps ({lane_rate} Gbps x {lanes} lanes)",
+                        lane_rate * lanes as f64
+                    )
+                    .unwrap();
+                }
+
                 text
             }
             DisplayConnector::Hdmi => "HDMI".to_owned(),

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -891,9 +891,9 @@ pub struct DisplayManufactureDate {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum DisplayConnector {
     DisplayPort {
-        lanes: u16,
+        lanes: Option<u16>,
         /// Per-lane bandwidth in Mbps
-        bandwidth: u32,
+        bandwidth: Option<u32>,
         embedded: bool,
     },
     Hdmi,


### PR DESCRIPTION
- Don't show 0 as the lane/bandwidth value when this information is not available
- Show a message if no displays are detected, instead of an empty page