### PR TITLE
feat: expand monitor info

### DIFF
--- a/lact-daemon/Cargo.toml
+++ b/lact-daemon/Cargo.toml
@@ -49,7 +49,7 @@ libcopes = "1.0.0"
 libloading = "0.8.9" # Can be updated when https://github.com/rust-lang/rust-bindgen/issues/3332 is released
 
 ureq = { version = "3.3.0", features = ["json", "rustls"] }
-libdisplay-info = { version= "0.3.0", optional = true }
+libdisplay-info = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/lact-daemon/src/server/display.rs
+++ b/lact-daemon/src/server/display.rs
@@ -1,5 +1,7 @@
 use anyhow::Context;
-use lact_schema::{DisplayConnector, DisplayInfo, DisplayManufactureDate, DisplaysInfo};
+use lact_schema::{
+    DisplayConnector, DisplayInfo, DisplayManufactureDate, DisplayRefreshRateRange, DisplaysInfo,
+};
 use std::{collections::BTreeMap, fs, path::Path};
 use tracing::warn;
 
@@ -114,8 +116,28 @@ fn get_display_entry(path: &Path) -> anyhow::Result<(String, DisplayInfo)> {
             .map(|(width, height)| (width as u32, height as u32)),
         connector_type,
         connector_id,
+        bit_depth: edid
+            .video_input_digital()
+            .and_then(|input| input.color_bit_depth)
+            .and_then(|depth| depth.try_into().ok()),
+        refresh_rate_range: get_refresh_rate_range(&edid),
     };
     Ok((connector.to_owned(), info))
+}
+
+fn get_refresh_rate_range(
+    edid: &libdisplay_info::edid::Edid<'_>,
+) -> Option<DisplayRefreshRateRange> {
+    edid.display_descriptors()
+        .iter()
+        .find_map(libdisplay_info::edid::DisplayDescriptorRef::range_limits)
+        .and_then(|range| {
+            (range.min_vert_rate_hz > 0 && range.max_vert_rate_hz >= range.min_vert_rate_hz)
+                .then_some(DisplayRefreshRateRange {
+                    min_hz: range.min_vert_rate_hz.try_into().ok()?,
+                    max_hz: range.max_vert_rate_hz.try_into().ok()?,
+                })
+        })
 }
 
 pub fn dp_rate_to_bandwidth(value: u32) -> u32 {

--- a/lact-gui/i18n/en/lact_gui.ftl
+++ b/lact-gui/i18n/en/lact_gui.ftl
@@ -240,6 +240,8 @@ display-model = Model
 display-physical-size = Physical Size
 display-connection = Connection
 display-manufacture-date = Manufacture Date
+display-bit-depth = Bit Depth
+display-refresh-rate-range = Refresh Range
 displays-missing = No Displays Detected
 
 settings-profile = Settings Profile

--- a/lact-gui/src/app/pages/displays_page.rs
+++ b/lact-gui/src/app/pages/displays_page.rs
@@ -128,6 +128,8 @@ impl relm4::factory::FactoryComponent for DisplayComponent {
                         format!("{width}cm x {height}cm")
                     }).unwrap_or_default(),
                     set_selectable: true,
+                } -> physical_size_row: gtk::FlowBoxChild {
+                    #[watch]
                     set_visible: self.info.size.is_some(),
                 },
 
@@ -147,7 +149,31 @@ impl relm4::factory::FactoryComponent for DisplayComponent {
                         }
                     }).unwrap_or_default(),
                     set_selectable: true,
+                } -> manufacture_date_row: gtk::FlowBoxChild {
+                    #[watch]
                     set_visible: self.info.manufacture_date.is_some(),
+                },
+
+                append_child = &InfoRow {
+                    set_name: fl!(I18N, "display-bit-depth"),
+                    set_value: self.info.bit_depth.map(|depth| {
+                        format!("{depth} bpc")
+                    }).unwrap_or_default(),
+                    set_selectable: true,
+                } -> bit_depth_row: gtk::FlowBoxChild {
+                    #[watch]
+                    set_visible: self.info.bit_depth.is_some(),
+                },
+
+                append_child = &InfoRow {
+                    set_name: fl!(I18N, "display-refresh-rate-range"),
+                    set_value: self.info.refresh_rate_range.map(|range| {
+                        format!("{}-{} Hz", range.min_hz, range.max_hz)
+                    }).unwrap_or_default(),
+                    set_selectable: true,
+                } -> refresh_rate_range_row: gtk::FlowBoxChild {
+                    #[watch]
+                    set_visible: self.info.refresh_rate_range.is_some(),
                 },
 
             },

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -880,12 +880,20 @@ pub struct DisplayInfo {
     pub size: Option<(u32, u32)>,
     pub connector_type: DisplayConnector,
     pub connector_id: u32,
+    pub bit_depth: Option<u8>,
+    pub refresh_rate_range: Option<DisplayRefreshRateRange>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct DisplayManufactureDate {
     pub year: u16,
     pub week: u8,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct DisplayRefreshRateRange {
+    pub min_hz: u16,
+    pub max_hz: u16,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
I was checking what else relevant can we expose from edid. hdr looks interesting, but I wouldn't dump whole struct inline. 

these 2 are no-brainers for both parsing and showing.