### PR TITLE
fix: nvidia displayport2 bandwidth calculation

### DIFF
--- a/lact-daemon/src/server/display.rs
+++ b/lact-daemon/src/server/display.rs
@@ -4,8 +4,7 @@ use std::{collections::BTreeMap, fs, path::Path};
 use tracing::warn;
 
 const BASE_RATE_MULTIPLIER: u32 = 270;
-pub const UHBR_RATE_MULTIPLIER: u32 = 10;
-const UHBR_RATE_THRESHOLD: u32 = 1000;
+const UHBR_RATE_MULTIPLIER: u32 = 10;
 
 pub fn get_base_displays_info(device_path: &Path) -> anyhow::Result<DisplaysInfo> {
     let path_parent = device_path.parent().context("Invalid path")?;
@@ -118,13 +117,12 @@ fn get_display_entry(path: &Path) -> anyhow::Result<(String, DisplayInfo)> {
     Ok((connector.to_owned(), info))
 }
 
-pub fn dp_rate_to_bandwidth(value: u32) -> u32 {
-    // Ref: https://elixir.bootlin.com/linux/v7.0.10/source/drivers/gpu/drm/amd/display/dc/dc_dp_types.h#L41
-    // Applies not only to AMD, as this is from the DP spec
-    // Values are for conversion to Mbps
-    if value < UHBR_RATE_THRESHOLD {
-        value * BASE_RATE_MULTIPLIER
-    } else {
-        value * UHBR_RATE_MULTIPLIER
-    }
+// Values are for conversion to Mbps
+pub fn dp1_rate_to_bandwidth(value: u32) -> u32 {
+    value * BASE_RATE_MULTIPLIER
+}
+
+// Values are for conversion to Mbps
+pub fn dp2_rate_to_bandwidth(value: u32) -> u32 {
+    value * UHBR_RATE_MULTIPLIER
 }

--- a/lact-daemon/src/server/display.rs
+++ b/lact-daemon/src/server/display.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, fs, path::Path};
 use tracing::warn;
 
 const BASE_RATE_MULTIPLIER: u32 = 270;
-const UHBR_RATE_MULTIPLIER: u32 = 10;
+pub const UHBR_RATE_MULTIPLIER: u32 = 10;
 const UHBR_RATE_THRESHOLD: u32 = 1000;
 
 pub fn get_base_displays_info(device_path: &Path) -> anyhow::Result<DisplaysInfo> {

--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -51,6 +51,7 @@ const AMDGPU_FAMILY_GC_11_0_0: u32 = 145;
 const FAN_CONTROL_RETRIES: u32 = 10;
 const MAX_PSTATE_READ_ATTEMPTS: u32 = 5;
 const REQUIRE_MANUAL_DEVICE_IDS: [&str; 3] = ["163F", "1435", "15BF"];
+const UHBR_RATE_THRESHOLD: u32 = 1000;
 const AMDGPU_IDS_FLAGS_FUSION: u64 = 0x1;
 const HSA_CACHE_TYPE_DATA: u32 = 0x0000_0001;
 const HSA_CACHE_TYPE_INSTRUCTION: u32 = 0x0000_0002;
@@ -1471,7 +1472,14 @@ impl GpuController for AmdGpuController {
                     .and_then(|value| u32::from_str_radix(value, 16).ok())
                     .context("Invalid bandwidth value")?;
 
-                *bandwidth = Some(crate::server::display::dp_rate_to_bandwidth(bw_enum));
+                // Ref: https://elixir.bootlin.com/linux/v7.0.10/source/drivers/gpu/drm/amd/display/dc/dc_dp_types.h#L41
+                // AMD reports legacy DP link rates as DP spec codes, while DP2 UHBR
+                // rates are reported in 10 Mbps units. UHBR10 starts at 1000.
+                *bandwidth = Some(if bw_enum < UHBR_RATE_THRESHOLD {
+                    crate::server::display::dp1_rate_to_bandwidth(bw_enum)
+                } else {
+                    crate::server::display::dp2_rate_to_bandwidth(bw_enum)
+                });
             }
         }
 

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -1343,13 +1343,17 @@ impl GpuController for NvidiaGpuController {
                             match handle.get_dp_link_config(display_id) {
                                 Ok(params) => {
                                     *lanes = Some(params.laneCount.try_into()?);
-                                    *bandwidth = Some(if params.linkBW != 0 {
-                                        crate::server::display::dp1_rate_to_bandwidth(params.linkBW)
-                                    } else {
-                                        crate::server::display::dp2_rate_to_bandwidth(
+                                    *bandwidth = if params.linkBW != 0 {
+                                        Some(crate::server::display::dp1_rate_to_bandwidth(
+                                            params.linkBW,
+                                        ))
+                                    } else if params.dp2LinkBW != 0 {
+                                        Some(crate::server::display::dp2_rate_to_bandwidth(
                                             params.dp2LinkBW,
-                                        )
-                                    });
+                                        ))
+                                    } else {
+                                        None
+                                    };
                                 }
                                 Err(err) => {
                                     warn!("could not fetch DP info for display {key}: {err:#}");

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -1343,17 +1343,13 @@ impl GpuController for NvidiaGpuController {
                             match handle.get_dp_link_config(display_id) {
                                 Ok(params) => {
                                     *lanes = Some(params.laneCount.try_into()?);
-                                    *bandwidth = if params.linkBW != 0 {
-                                        Some(crate::server::display::dp1_rate_to_bandwidth(
-                                            params.linkBW,
-                                        ))
-                                    } else if params.dp2LinkBW != 0 {
-                                        Some(crate::server::display::dp2_rate_to_bandwidth(
-                                            params.dp2LinkBW,
-                                        ))
+                                    *bandwidth = Some(if params.linkBW != 0 {
+                                        crate::server::display::dp1_rate_to_bandwidth(params.linkBW)
                                     } else {
-                                        None
-                                    };
+                                        crate::server::display::dp2_rate_to_bandwidth(
+                                            params.dp2LinkBW,
+                                        )
+                                    });
                                 }
                                 Err(err) => {
                                     warn!("could not fetch DP info for display {key}: {err:#}");

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -1343,9 +1343,13 @@ impl GpuController for NvidiaGpuController {
                             match handle.get_dp_link_config(display_id) {
                                 Ok(params) => {
                                     *lanes = Some(params.laneCount.try_into()?);
-                                    *bandwidth = Some(
-                                        crate::server::display::dp_rate_to_bandwidth(params.linkBW),
-                                    );
+                                    *bandwidth = Some(if params.linkBW != 0 {
+                                        crate::server::display::dp_rate_to_bandwidth(params.linkBW)
+                                    } else {
+                                        use crate::server::display::UHBR_RATE_MULTIPLIER;
+
+                                        params.dp2LinkBW * UHBR_RATE_MULTIPLIER
+                                    });
                                 }
                                 Err(err) => {
                                     warn!("could not fetch DP info for display {key}: {err:#}");

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -1344,11 +1344,11 @@ impl GpuController for NvidiaGpuController {
                                 Ok(params) => {
                                     *lanes = Some(params.laneCount.try_into()?);
                                     *bandwidth = Some(if params.linkBW != 0 {
-                                        crate::server::display::dp_rate_to_bandwidth(params.linkBW)
+                                        crate::server::display::dp1_rate_to_bandwidth(params.linkBW)
                                     } else {
-                                        use crate::server::display::UHBR_RATE_MULTIPLIER;
-
-                                        params.dp2LinkBW * UHBR_RATE_MULTIPLIER
+                                        crate::server::display::dp2_rate_to_bandwidth(
+                                            params.dp2LinkBW,
+                                        )
                                     });
                                 }
                                 Err(err) => {


### PR DESCRIPTION
@ilya-zlobintsev I was learning how you implemented dp2 bandwidth and noticed a potential problem.
What I found interesting - the are 2 values exposed on nvidia link config params, one for dp1 and one for dp2, but we're using only dp1

header says they're mutually exclusive - https://github.com/ilya-zlobintsev/LACT/blob/36e273fc90726b1db54faf5bcc61f5f9bc69f81e/lact-daemon/include/nvidia/src/common/sdk/nvidia/inc/ctrl/ctrl0073/ctrl0073dp.h#L1308

then I asked llm to check this path e2e, and it pointed to another possible problem - 

there are some valid values defined for nvidia which are below UHBR_RATE_THRESHOLD
https://github.com/ilya-zlobintsev/LACT/blob/36e273fc90726b1db54faf5bcc61f5f9bc69f81e/lact-daemon/include/nvidia/src/common/sdk/nvidia/inc/ctrl/ctrl0073/ctrl0073dp.h#L1348

the "fix" is rather ugly and mostly to demonstrate the problem. I have an Idea how to express it better, but want to get your feedback before, maybe I'm missing something