### PR TITLE
fix: blackwell nvapi temps parsing

### DIFF
--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -754,7 +754,12 @@ impl GpuController for NvidiaGpuController {
                         );
                     }
 
-                    if let Some(vram) = thermals.vram(arch.as_ref()) {
+                    let vram_type = self
+                        .driver_handle
+                        .as_ref()
+                        .and_then(|driver| driver.get_ram_type().ok());
+
+                    if let Some(vram) = thermals.vram(vram_type) {
                         temps.insert(
                             "VRAM".to_owned(),
                             TemperatureEntry {

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -733,11 +733,13 @@ impl GpuController for NvidiaGpuController {
         let mut voltage = None;
 
         if let Some((nvapi, handle)) = self.nvapi.as_ref() {
+            let arch = device.architecture().ok();
+
             unsafe {
                 if let Some(mask) = self.nvapi_thermals_mask
                     && let Ok(thermals) = nvapi.get_thermals(*handle, mask)
                 {
-                    if let Some(hotspot) = thermals.hotspot() {
+                    if let Some(hotspot) = thermals.hotspot(arch.as_ref()) {
                         temps.insert(
                             "GPU Hotspot".to_owned(),
                             TemperatureEntry {
@@ -752,7 +754,7 @@ impl GpuController for NvidiaGpuController {
                         );
                     }
 
-                    if let Some(vram) = thermals.vram() {
+                    if let Some(vram) = thermals.vram(arch.as_ref()) {
                         temps.insert(
                             "VRAM".to_owned(),
                             TemperatureEntry {

--- a/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
@@ -320,15 +320,16 @@ impl NvApiThermals {
     }
 
     pub fn hotspot(&self, arch: Option<&DeviceArchitecture>) -> Option<i32> {
-        match arch {
-            Some(DeviceArchitecture::Blackwell) => None,
-            _ => self.get_value(9),
+        if arch.is_some_and(|arch| arch.as_c() >= DeviceArchitecture::Blackwell.as_c()) {
+            None
+        } else {
+            self.get_value(9)
         }
     }
 
-    pub fn vram(&self, arch: Option<&DeviceArchitecture>) -> Option<i32> {
-        match arch {
-            Some(DeviceArchitecture::Blackwell) => self.get_value(10),
+    pub fn vram(&self, vram_type: Option<&str>) -> Option<i32> {
+        match vram_type {
+            Some("GDDR7") => self.get_value(10),
             _ => self.get_value(15),
         }
     }

--- a/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
@@ -10,6 +10,7 @@ use crate::bindings::nvidia::{
     NvU8, NvU32,
 };
 use anyhow::{Context, bail};
+use nvml_wrapper::enums::device::DeviceArchitecture;
 use std::{
     ffi::{CStr, c_char},
     mem::{self, transmute},
@@ -318,12 +319,18 @@ impl NvApiThermals {
             .filter(|&value| value > 0 && value < 255)
     }
 
-    pub fn hotspot(&self) -> Option<i32> {
-        self.get_value(9)
+    pub fn hotspot(&self, arch: Option<&DeviceArchitecture>) -> Option<i32> {
+        match arch {
+            Some(DeviceArchitecture::Blackwell) => None,
+            _ => self.get_value(9),
+        }
     }
 
-    pub fn vram(&self) -> Option<i32> {
-        self.get_value(15)
+    pub fn vram(&self, arch: Option<&DeviceArchitecture>) -> Option<i32> {
+        match arch {
+            Some(DeviceArchitecture::Blackwell) => self.get_value(10),
+            _ => self.get_value(15),
+        }
     }
 }
 


### PR DESCRIPTION
Seems like temps mapping on blackwell is different from ada.

this PR takes mapping from
https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/1878
their temp1 matches 9, temp2 matches 10, e.t.c

I tested sensors on the server and 9 matches core temp, 10 seems like vram, others are invalid including 15. Haven't tested lact itself.