### PR TITLE
chore: avoid needlessly formatting values with .0 in graphs

### DIFF
--- a/lact-gui/src/app.rs
+++ b/lact-gui/src/app.rs
@@ -469,6 +469,7 @@ impl AsyncComponent for AppModel {
             .expect("Failed to get application from root window");
         setup_actions! {
             (actions, ProcessMonitorAction, APP_BROKER.send(AppMsg::ShowProcessMonitor)),
+            (actions, HistoricalGraphsAction, APP_BROKER.send(AppMsg::ShowGraphsWindow)),
             (actions, GenerateDebugSnapshotAction, APP_BROKER.send(AppMsg::DebugSnapshot)),
             (actions, PreferencesAction, APP_BROKER.send(AppMsg::ShowPreferencesDialog)),
             (actions, AboutAction, APP_BROKER.send(AppMsg::ShowAboutDialog)),
@@ -486,6 +487,8 @@ impl AsyncComponent for AppModel {
             gio_action
         };
         application.set_accelerators_for_action::<PreferencesAction>(&["<Control>comma"]);
+        application.set_accelerators_for_action::<HistoricalGraphsAction>(&["<Control>g"]);
+        application.set_accelerators_for_action::<ProcessMonitorAction>(&["<Control>p"]);
         application.set_accelerators_for_action::<QuitAction>(&["<Control>q"]);
         root.insert_action_group(AppActionGroup::NAME, Some(&actions.into_action_group()));
 
@@ -1458,6 +1461,7 @@ async fn create_connection() -> anyhow::Result<(DaemonClient, Option<anyhow::Err
 
 new_action_group!(pub AppActionGroup, "app");
 new_stateless_action!(pub ProcessMonitorAction, AppActionGroup, "show-process-monitor");
+new_stateless_action!(pub HistoricalGraphsAction, AppActionGroup, "show-historical-graphs");
 new_stateless_action!(pub GenerateDebugSnapshotAction, AppActionGroup, "generate-debug-snapshot");
 new_stateless_action!(pub DumpVBiosAction, AppActionGroup, "dump-vbios");
 new_stateless_action!(pub PreferencesAction, AppActionGroup, "preferences");

--- a/lact-gui/src/app/graphs_window/plot/render_thread.rs
+++ b/lact-gui/src/app/graphs_window/plot/render_thread.rs
@@ -288,15 +288,19 @@ impl RenderRequest {
             let avg_value = data.iter().map(|(_, val)| *val).sum::<f64>() / data.len() as f64;
 
             let stat_suffix = stat_type.metric();
+            let precision = stat_type.precision();
 
-            let mut stat_label =
-                format!("{}: {current_value:.1}{stat_suffix}", stat_type.display(),);
+            let mut stat_label = format!(
+                "{}: {current_value:.*}{stat_suffix}",
+                stat_type.display(),
+                precision
+            );
             if self.print_extra_info {
                 if stat_type.show_peak() {
-                    write!(stat_label, ", Peak {max_value:.1}{stat_suffix}").unwrap();
+                    write!(stat_label, ", Peak {max_value:.*}{stat_suffix}", precision).unwrap();
                 }
 
-                write!(stat_label, ", Avg {avg_value:.1}{stat_suffix}").unwrap();
+                write!(stat_label, ", Avg {avg_value:.*}{stat_suffix}", precision).unwrap();
             }
 
             // Evaluate fixed number of points per spline segment

--- a/lact-gui/src/app/graphs_window/stat.rs
+++ b/lact-gui/src/app/graphs_window/stat.rs
@@ -283,6 +283,21 @@ impl StatType {
         }
     }
 
+    /// How many digits should be formatted
+    pub fn precision(&self) -> usize {
+        use StatType::*;
+        match self {
+            GpuClock | GpuTargetClock | VramClock | Clockspeed(_) => 0,
+            FanPwm => 1,
+            FanRpm => 0,
+            PowerCurrent | PowerAverage | Power(_) => 1,
+            PowerCap => 0,
+            Temperature(_) => 1,
+            GpuUsage | VramSize | VramUsed | GttSize | GttUsed => 0,
+            GpuVoltage | Voltage(_) => 0,
+        }
+    }
+
     pub fn show_peak(&self) -> bool {
         use StatType::*;
         !matches!(self, VramSize | PowerCap)


### PR DESCRIPTION
Before:
<img width="441" height="354" alt="image" src="https://github.com/user-attachments/assets/ef9e79bf-b8b6-4f0c-a60c-75a72d0778c0" />
After:
<img width="400" height="358" alt="image" src="https://github.com/user-attachments/assets/097b3ea2-0f3d-4b35-9fee-016f76ace251" />

Additionally, this adds keyboard shortcuts for the graphs window and process monitor (Ctrl+G and Ctrl+P respectively)