### PR TITLE
feat: add configurable NVIDIA initialization mode

### DIFF
--- a/lact-daemon/src/lib.rs
+++ b/lact-daemon/src/lib.rs
@@ -13,8 +13,9 @@ mod tests;
 use anyhow::Context;
 use config::Config;
 use futures::future::select_all;
+pub use lact_schema::NvidiaInitMode;
 use server::{Server, handle_stream, handler::Handler};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::{os::unix::net::UnixStream as StdUnixStream, time::Duration};
 use tokio::net::UnixStream;
 use tokio::runtime::LocalOptions;
@@ -32,6 +33,13 @@ use crate::server::ClientContext;
 pub use system::BASE_MODULE_CONF_PATH;
 
 const DRM_EVENT_TIMEOUT_PERIOD_MS: u64 = 100;
+static NVIDIA_INIT_MODE: OnceLock<NvidiaInitMode> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct DaemonOptions {
+    pub nvidia_init_mode: NvidiaInitMode,
+}
+
 const SHUTDOWN_SIGNALS: [SignalKind; 4] = [
     SignalKind::terminate(),
     SignalKind::interrupt(),
@@ -44,6 +52,16 @@ const SHUTDOWN_SIGNALS: [SignalKind; 4] = [
 /// # Errors
 /// Returns an error when the daemon cannot initialize.
 pub fn run() -> anyhow::Result<()> {
+    run_with_options(DaemonOptions::default())
+}
+
+/// Run the daemon with explicit initialization options, binding to the default socket.
+///
+/// # Errors
+/// Returns an error when the daemon cannot initialize.
+pub fn run_with_options(options: DaemonOptions) -> anyhow::Result<()> {
+    configure_nvidia_init_mode(options.nvidia_init_mode)?;
+
     let rt = runtime::Builder::new_current_thread()
         .enable_all()
         .build_local(LocalOptions::default())
@@ -68,6 +86,24 @@ pub fn run() -> anyhow::Result<()> {
         server.run().await;
         Ok(())
     })
+}
+
+fn configure_nvidia_init_mode(mode: NvidiaInitMode) -> anyhow::Result<()> {
+    if let Some(configured_mode) = NVIDIA_INIT_MODE.get() {
+        if *configured_mode == mode {
+            return Ok(());
+        }
+        anyhow::bail!("Nvidia initialization mode is already configured as {configured_mode:?}");
+    }
+
+    NVIDIA_INIT_MODE
+        .set(mode)
+        .map_err(|_| anyhow::anyhow!("Could not configure Nvidia initialization mode"))
+}
+
+#[cfg(all(not(test), feature = "nvidia"))]
+pub(crate) fn nvidia_init_mode() -> NvidiaInitMode {
+    *NVIDIA_INIT_MODE.get_or_init(NvidiaInitMode::default)
 }
 
 /// Run the daemon with a given `UnixStream`.

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -29,7 +29,7 @@ use libdrm_amdgpu_sys::LibDrmAmdgpu;
 use libflate::gzip;
 use nix::libc;
 #[cfg(all(not(test), feature = "nvidia"))]
-use nvml_wrapper::Nvml;
+use nvml_wrapper::{Nvml, bitmasks::InitFlags};
 use pciid_parser::Database;
 use serde_json::json;
 #[cfg(all(not(test), feature = "nvidia"))]
@@ -1324,8 +1324,13 @@ pub(crate) static NVML: LazyLock<Option<NvidiaLibs>> = LazyLock::new(|| None);
 // Loading of shared libaries is unsafe
 // https://docs.rs/libloading/0.8.8/libloading/struct.Library.html#method.new
 #[allow(unused_unsafe)]
-pub(crate) static NVML: LazyLock<Option<NvidiaLibs>> =
-    LazyLock::new(|| match unsafe { Nvml::init() } {
+pub(crate) static NVML: LazyLock<Option<NvidiaLibs>> = LazyLock::new(|| {
+    match unsafe {
+        match crate::nvidia_init_mode() {
+            lact_schema::NvidiaInitMode::Normal => Nvml::init(),
+            lact_schema::NvidiaInitMode::AllowNoGpus => Nvml::init_with_flags(InitFlags::NO_GPUS),
+        }
+    } {
         Ok(nvml) => {
             use crate::server::gpu_controller::NvApi;
 
@@ -1356,7 +1361,8 @@ pub(crate) static NVML: LazyLock<Option<NvidiaLibs>> =
             error!("could not load Nvidia management library: {err}");
             None
         }
-    });
+    }
+});
 
 pub(crate) static AMD_DRM: LazyLock<Option<LibDrmAmdgpu>> = LazyLock::new(|| {
     // SAFETY: We use global LazyLock to make sure it's safe.

--- a/lact-schema/src/args.rs
+++ b/lact-schema/src/args.rs
@@ -2,7 +2,7 @@ pub mod cli;
 
 pub use clap;
 
-use crate::args::cli::CliArgs;
+use crate::{NvidiaInitMode, args::cli::CliArgs};
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -14,11 +14,18 @@ pub struct Args {
 #[derive(Subcommand)]
 pub enum Command {
     /// Run the daemon
-    Daemon,
+    Daemon(DaemonArgs),
     /// Run the GUI
     Gui(GuiArgs),
     /// Run the CLI
     Cli(CliArgs),
+}
+
+#[derive(Default, Parser)]
+pub struct DaemonArgs {
+    /// Select how the daemon initializes the Nvidia management library
+    #[arg(long, value_enum, default_value = "normal")]
+    pub nvidia_init_mode: NvidiaInitMode,
 }
 
 #[derive(Default, Parser)]
@@ -28,4 +35,30 @@ pub struct GuiArgs {
     /// Remote TCP address to connect to
     #[arg(long)]
     pub tcp_address: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_uses_normal_nvidia_init_by_default() {
+        let args = Args::try_parse_from(["lact", "daemon"]).unwrap();
+        let Some(Command::Daemon(daemon_args)) = args.command else {
+            panic!("daemon command was not parsed");
+        };
+
+        assert_eq!(daemon_args.nvidia_init_mode, NvidiaInitMode::Normal);
+    }
+
+    #[test]
+    fn parses_allow_no_gpus_nvidia_init_mode() {
+        let args =
+            Args::try_parse_from(["lact", "daemon", "--nvidia-init-mode=allow-no-gpus"]).unwrap();
+        let Some(Command::Daemon(daemon_args)) = args.command else {
+            panic!("daemon command was not parsed");
+        };
+
+        assert_eq!(daemon_args.nvidia_init_mode, NvidiaInitMode::AllowNoGpus);
+    }
 }

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -37,6 +37,16 @@ use crate::{config::ProfileHooks, i18n::LANGUAGE_LOADER};
 
 pub const GIT_COMMIT: &str = env!("VERGEN_GIT_SHA");
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "args", derive(clap::ValueEnum))]
+pub enum NvidiaInitMode {
+    /// Initialize NVML using its default behavior.
+    #[default]
+    Normal,
+    /// Allow the daemon to start when NVML cannot see any Nvidia GPUs.
+    AllowNoGpus,
+}
+
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum FanControlMode {

--- a/lact/src/main.rs
+++ b/lact/src/main.rs
@@ -7,7 +7,9 @@ fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| Command::Gui(GuiArgs::default()));
 
     match command {
-        Command::Daemon => lact_daemon::run(),
+        Command::Daemon(daemon_args) => lact_daemon::run_with_options(lact_daemon::DaemonOptions {
+            nvidia_init_mode: daemon_args.nvidia_init_mode,
+        }),
         Command::Gui(gui_args) => run_gui(gui_args),
         Command::Cli(cli_args) => lact_cli::run(cli_args),
     }


### PR DESCRIPTION
Problem: If NVML initialization fails while no NVIDIA GPU is available, LACT's existing re-enumeration logic cannot create an NVIDIA controller when a GPU is later hot-plugged or returned from VFIO.

Fix: Add an `allow-no-gpus` initialization mode so NVML can initialize without a visible NVIDIA GPU and handle it when it becomes available.