### PR TITLE
feat: add `detach` & `attach` commands for multi-GPU environments without losing current settings briefly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Linux GPU Control Application
+
 <a href="https://translate.fedoraproject.org/engage/lact/">
 <img src="https://translate.fedoraproject.org/widget/lact/svg-badge.svg" alt="Translation status" />
 </a>
@@ -9,7 +10,7 @@ This application allows you to control your AMD, Nvidia or Intel GPU on a Linux
 system.
 
 | GPU info                          | Overclocking                      | Fan control                       |
-| ----------------------------------| ----------------------------------| ----------------------------------|
+| --------------------------------- | --------------------------------- | --------------------------------- |
 | ![image](./res/screenshots/1.png) | ![image](./res/screenshots/2.png) | ![image](./res/screenshots/3.png) |
 | Software info                     | Historical data                   |                                   |
 | ![image](./res/screenshots/4.png) | ![image](./res/screenshots/5.png) |                                   |
@@ -49,7 +50,7 @@ The service can also be used standalone with a config file, for example in headl
 - [Installation](#installation)
 - [Hardware support](https://github.com/ilya-zlobintsev/LACT/wiki/Hardware-Support)
 - [Frequently asked questions](https://github.com/ilya-zlobintsev/LACT/wiki/Frequently-asked-questions)
-- [Enable overclocking on AMD](https://github.com/ilya-zlobintsev/LACT/wiki/Overclocking-(AMD))
+- [Enable overclocking on AMD](<https://github.com/ilya-zlobintsev/LACT/wiki/Overclocking-(AMD)>)
 - [Config file reference](./docs/CONFIG.md)
 - [API](./docs/API.md)
 - [Power profiles daemon note](#power-profiles-daemon-note)
@@ -68,6 +69,7 @@ The service can also be used standalone with a config file, for example in headl
 
   It is only available on Debian 12+ and Ubuntu 22.04+ as older versions don't
   ship gtk4.
+
 - Fedora: use the
   [Copr repository](https://copr.fedorainfracloud.org/coprs/ilyaz/LACT/), or
   download an RPM from
@@ -80,12 +82,14 @@ The service can also be used standalone with a config file, for example in headl
 
   Only tumbleweed is supported as leap does not have the required dependencies
   in the repos.
+
 - NixOS: There is a package available in
   [nixpkgs](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=lact).
 - Solus: Available in the offical repository: `eopkg it lact`
 - Flatpak (universal): Available on [Flathub](https://flathub.org/apps/io.github.ilya_zlobintsev.LACT) and in [releases](https://github.com/ilya-zlobintsev/LACT/releases/).
 
   See the [Flatpak documentation](./flatpak/README.md) for additional notes.
+
 - Docker (service only, no GUI): See [DOCKER.md](./docs/DOCKER.md)
 - Build from source.
 
@@ -151,7 +155,7 @@ and under the `daemon` section either:
 # Overclocking (AMD)
 
 Some functionality requires enabling an option in the amdgpu driver, see the
-[wiki page](https://github.com/ilya-zlobintsev/LACT/wiki/Overclocking-(AMD)) for
+[wiki page](<https://github.com/ilya-zlobintsev/LACT/wiki/Overclocking-(AMD)>) for
 more information.
 
 ## Power profiles daemon note!
@@ -160,7 +164,7 @@ If you are using `power-profiles-daemon` (which is installed by default on many
 distributions), by default it may override the amdgpu performance level setting
 according to its own profile.
 
-When using LACT 0.7.5+ and power-profiles-daemon 0.30+, LACT will try to connect to power-profiles-daemon 
+When using LACT 0.7.5+ and power-profiles-daemon 0.30+, LACT will try to connect to power-profiles-daemon
 and automatically disable the conflicting amdgpu action in ppd to avoid this conflict.
 
 If running older versions, you can resolve this manually by creating a file at
@@ -200,6 +204,7 @@ Dependencies:
 - libdisplay-info
 
 Optional Dependencies:
+
 - vulkan-tools
 - clinfo
 
@@ -265,6 +270,7 @@ There is also a cli available.
   ```
   10DE:2704-1462:5110-0000:09:00.0 (AD103 [GeForce RTX 4080])
   ```
+
 - Getting GPU information:
 
   `lact cli info`
@@ -293,9 +299,23 @@ There is also a cli available.
   Link Speed: 8 GT/s PCIe gen 3 x8
   ```
 
+- Release a GPU before changing its PCI driver, then restore LACT management:
+
+  ```sh
+  lact cli --gpu-id 10DE:2704-1462:5110-0000:09:00.0 detach
+  # Change the device driver here.
+  lact cli --gpu-id 10DE:2704-1462:5110-0000:09:00.0 attach
+  ```
+
+  Both commands accept the same GPU index or full GPU ID as the other CLI
+  commands. LACT remembers the selected index while the GPU is unavailable.
+  `detach` releases LACT's handles for the selected GPU without stopping
+  management of GPUs from other vendors. `attach` reapplies the saved
+  configuration when the GPU is available again. These commands do not bind or
+  unbind PCI drivers.
+
 - Profiles
   `lact cli profile [COMMAND]`
-
   - List profiles:
 
     `lact cli profile list`
@@ -331,36 +351,35 @@ There is also a cli available.
 
     - Auto switch profiles
       `lact cli profile auto-switch [COMMAND]`
+      - Get auto-switch state:
 
-        - Get auto-switch state:
+        `lact cli profile auto-switch get` or `lact cli profile auto-switch`
 
-          `lact cli profile auto-switch get` or `lact cli profile auto-switch`
+        Example output:
 
-          Example output:
+        ```
+        enabled
+        ```
 
-          ```
-          enabled
-          ```
+      - Enable auto switch:
 
-        - Enable auto switch:
+        `lact cli profile auto-switch enable`
 
-          `lact cli profile auto-switch enable`
+        Example output:
 
-          Example output:
+        ```
+        enabled
+        ```
 
-          ```
-          enabled
-          ```
+      - Disable auto switch:
 
-        - Disable auto switch:
+        `lact cli profile auto-switch disable`
 
-          `lact cli profile auto-switch disable`
+        Example output:
 
-          Example output:
-
-          ```
-          disabled
-          ```
+        ```
+        disabled
+        ```
 
 The functionality of the CLI is quite limited. If you want to integrate LACT
 with some application/script, you should use the [API](./docs/API.md) instead.
@@ -392,6 +411,7 @@ If you wish to support the project, you can do so via Patreon:
 https://www.patreon.com/IlyaZlobintsev
 
 Or using cryptocurrency:
+
 - BTC: `12FuTXZzd5peGb7QfoRkXaLnbJ1DNVW4pP`
 - ETH: `0x80875173316aa6317641bfbc50644e7ca74d6b6d`
 - XMR: `42E93NZXM7STBUsnMRGNyxKryFVgpHKNP6aza94C5hn17j2W7zUnFHe7ASQzB3KorYYnsaVzWUyHHVYfcTLQRtB63qkv5jE`

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,32 +5,40 @@ The LACT Daemon exposes a JSON API over a unix socket or TCP, available on `/run
 The API expects newline-separated JSON objects, and returns a JSON object for every request.
 
 The general format of requests looks like:
+
 ```
 {"command": "command_name", "args": {}}
 ```
+
 Note that the type of `args` depends on the specific request, and may be omitted in some cases.
 
 The response looks like this:
+
 ```
 {"status": "ok|error", "data": {}}
 ```
+
 Same as `args` in requests, `data` can be of a different type and may not be present depending on the specific request.
 
 You can try sending commands to socket interactively with `ncat`:
+
 ```
 echo '{"command": "list_devices"}' | ncat -U /run/lactd.sock
 ```
+
 Example response:
+
 ```
 {"status":"ok","data":[{"id":"1002:687F-1043:0555-0000:0b:00.0","name":"Vega 10 XL/XT [Radeon RX Vega 56/64]"}]}
 ```
 
 Here's an example of calling the API with arguments to change a profile:
+
 ```
 echo '{"command": "set_profile", "args": {"name":"name-of-the-profile"}}' | ncat -U /run/lactd.sock
 ```
-In this code, `name-of-the-profile` should be replaced with the name of a profile that you've already created in LACT.
 
+In this code, `name-of-the-profile` should be replaced with the name of a profile that you've already created in LACT.
 
 # Commands
 
@@ -41,29 +49,60 @@ Additionally, each config change must be confirmed, or it will be automatically 
 
 **Deprecated commands**: there is a number of `set_` commands in the API that change individual settings. They are still functional for backwards compatibility purposes, but the `get_gpu_config`/`set_gpu_config` commands should be preferred instead.
 
+## GPU driver changes
+
+Use `detach_gpu` before unbinding a GPU from its current PCI driver. This stops
+LACT tasks for that GPU, resets its settings, closes its device handles, and
+prevents DRM events from recreating its controller. GPUs from other vendors
+remain managed. Because NVML and NvAPI are process-wide, other Nvidia
+controllers are briefly released and recreated after the detached GPU leaves
+the Nvidia driver; their saved configurations are reapplied.
+
+```sh
+echo '{"command":"detach_gpu","args":{"id":"10DE:2704-1462:5110-0000:09:00.0"}}' | nc -U /run/lactd.sock
+```
+
+Use `attach_gpu` to allow LACT to manage the GPU again. If the GPU is already
+available, LACT immediately recreates its controller and reapplies its saved
+configuration. Otherwise, the request succeeds and LACT attaches it after a
+later DRM event.
+
+```sh
+echo '{"command":"attach_gpu","args":{"id":"10DE:2704-1462:5110-0000:09:00.0"}}' | nc -U /run/lactd.sock
+```
+
+Both commands are idempotent and return the full LACT GPU ID. The `id` field
+uses the same full GPU ID as the other API commands. It can be omitted when
+there is only one unambiguous GPU. These commands only control LACT management;
+they do not bind or unbind PCI drivers.
+
 Example: how to set the power limit through the API:
 
 1. Get GPU id
+
 ```
-> echo '{"command": "list_devices"}' | nc -U /run/lactd.sock 
+> echo '{"command": "list_devices"}' | nc -U /run/lactd.sock
 {"status":"ok","data":[{"id":"10DE:2704-1462:5110-0000:09:00.0","name":"AD103 [GeForce RTX 4080]"}]}
 ```
 
 2. Get current config
+
 ```
-> echo '{"command": "get_gpu_config", "args": {"id": "10DE:2704-1462:5110-0000:09:00.0"}}' | nc -U /run/lactd.sock 
+> echo '{"command": "get_gpu_config", "args": {"id": "10DE:2704-1462:5110-0000:09:00.0"}}' | nc -U /run/lactd.sock
 {"status":"ok","data":{"fan_control_enabled":false,"fan_control_settings":{"mode":"static","static_speed":1.0,"temperature_key":"edge","interval_ms":500,"curve":{"40":0.3,"50":0.35,"60":0.5,"70":0.75,"80":1.0},"spindown_delay_ms":2856,"change_threshold":2},"power_cap":320.0}}
 ```
 
 3. Set a new config
 
 The `power_cap` field has been changed from the previous config
+
 ```
 > echo '{"command": "set_gpu_config", "args": {"id": "10DE:2704-1462:5110-0000:09:00.0", "config": {"fan_control_enabled":false,"fan_control_settings":{"mode":"static","static_speed":1.0,"temperature_key":"edge","interval_ms":500,"curve":{"40":0.3,"50":0.35,"60":0.5,"70":0.75,"80":1.0},"spindown_delay_ms":2856,"change_threshold":2},"power_cap":340.0}}}' | nc -U /run/lactd.sock
 {"status":"ok","data":5}
 ```
 
 4. Confirm new config
+
 ```
 > echo '{"command": "confirm_pending_config", "args": {"command": "confirm"}}' | nc -U /run/lactd.sock
 {"status":"ok","data":null}

--- a/lact-cli/src/lib.rs
+++ b/lact-cli/src/lib.rs
@@ -1,8 +1,8 @@
 mod subcommands;
 
 use crate::subcommands::{
-    current_auto_switch, current_profile, info, list_gpus, list_profiles, power_limit,
-    set_auto_switch, set_profile, snapshot, stats,
+    attach_gpu, current_auto_switch, current_profile, detach_gpu, info, list_gpus, list_profiles,
+    power_limit, set_auto_switch, set_profile, snapshot, stats,
 };
 use anyhow::{Context, Result, bail};
 use lact_client::DaemonClient;
@@ -27,6 +27,8 @@ pub fn run(args: CliArgs) -> Result<()> {
 
         match &args.subcommand {
             CliCommand::List => list_gpus(ctx).await,
+            CliCommand::Detach => detach_gpu(ctx).await,
+            CliCommand::Attach => attach_gpu(ctx).await,
             CliCommand::Info => info(ctx).await,
             CliCommand::Stats => stats(ctx).await,
             CliCommand::Snapshot => snapshot(ctx).await,

--- a/lact-cli/src/subcommands.rs
+++ b/lact-cli/src/subcommands.rs
@@ -23,6 +23,41 @@ pub async fn list_gpus(ctx: CliContext<'_>) -> Result<()> {
     Ok(())
 }
 
+pub async fn detach_gpu(ctx: CliContext<'_>) -> Result<()> {
+    let id = if ctx.args.gpu_id.is_some() {
+        Some(ctx.current_gpu_id().await?)
+    } else {
+        None
+    };
+    let id = ctx
+        .client
+        .detach_gpu(id.as_deref())
+        .await
+        .context("Could not detach GPU from LACT management")?;
+    println!("Detached GPU {id}");
+    Ok(())
+}
+
+pub async fn attach_gpu(ctx: CliContext<'_>) -> Result<()> {
+    let id = ctx
+        .client
+        .attach_gpu(ctx.args.gpu_id.as_deref())
+        .await
+        .context("Could not attach GPU to LACT management")?;
+    let attached = ctx
+        .client
+        .list_devices()
+        .await?
+        .into_iter()
+        .any(|device| device.id == id);
+    if attached {
+        println!("Attached GPU {id}");
+    } else {
+        println!("GPU {id} will attach when available");
+    }
+    Ok(())
+}
+
 pub async fn info(ctx: CliContext<'_>) -> Result<()> {
     let id = ctx.current_gpu_id().await?;
 

--- a/lact-client/src/lib.rs
+++ b/lact-client/src/lib.rs
@@ -126,6 +126,14 @@ impl DaemonClient {
         self.make_request(Request::ListDevices).await
     }
 
+    pub async fn detach_gpu(&self, id: Option<&str>) -> anyhow::Result<String> {
+        self.make_request(Request::DetachGpu { id }).await
+    }
+
+    pub async fn attach_gpu(&self, id: Option<&str>) -> anyhow::Result<String> {
+        self.make_request(Request::AttachGpu { id }).await
+    }
+
     pub async fn get_device_info(
         &self,
         id: &str,

--- a/lact-daemon/src/server.rs
+++ b/lact-daemon/src/server.rs
@@ -175,6 +175,8 @@ async fn handle_request<'a>(
         Request::Ping => ok_response(ping()),
         Request::SystemInfo => ok_response(system::info().await?),
         Request::ListDevices => ok_response(handler.list_devices().await),
+        Request::DetachGpu { id } => ok_response(handler.detach_gpu(id).await?),
+        Request::AttachGpu { id } => ok_response(handler.attach_gpu(id).await?),
         Request::DeviceInfo {
             id,
             include_api_info,

--- a/lact-daemon/src/server/gpu_controller.rs
+++ b/lact-daemon/src/server/gpu_controller.rs
@@ -17,7 +17,9 @@ use tokio::join;
 pub const VENDOR_AMD: &str = "1002";
 pub const VENDOR_NVIDIA: &str = "10DE";
 
-use crate::server::handler::{AMD_DRM, INTEL_DRM, NVML};
+#[cfg(all(feature = "nvidia", not(test)))]
+use crate::config::Config;
+use crate::server::handler::{AMD_DRM, INTEL_DRM};
 use crate::server::opencl::get_opencl_info;
 use crate::server::vulkan::get_vulkan_info;
 use amdgpu_sysfs::gpu_handle::power_profile_mode::PowerProfileModesTable;
@@ -30,8 +32,17 @@ use lact_schema::{
 use std::io;
 #[cfg(feature = "nvidia")]
 use std::sync::Arc;
-use std::{collections::HashMap, fs, path::PathBuf, rc::Rc};
+#[cfg(all(feature = "nvidia", not(test)))]
+use std::sync::{LazyLock, Mutex};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 use tokio::{sync::Notify, task::JoinHandle};
+#[cfg(all(feature = "nvidia", not(test)))]
+use tracing::info;
 use tracing::{error, warn};
 
 #[cfg(feature = "nvidia")]
@@ -167,17 +178,77 @@ pub struct PciSlotInfo {
 }
 
 #[cfg(feature = "nvidia")]
-pub type NvidiaLibs = (Arc<Nvml>, Arc<Option<NvApi>>);
-#[cfg(not(feature = "nvidia"))]
-pub type NvidiaLibs = ();
+#[derive(Clone)]
+pub struct NvidiaLibs {
+    pub nvapi: Option<Arc<NvApi>>,
+    pub nvml: Arc<Nvml>,
+}
+#[cfg(all(feature = "nvidia", not(test)))]
+static NVIDIA_LIBS: LazyLock<Mutex<Option<NvidiaLibs>>> = LazyLock::new(|| Mutex::new(None));
+
+#[cfg(all(feature = "nvidia", not(test)))]
+fn get_nvidia_libs() -> Option<NvidiaLibs> {
+    let mut guard = NVIDIA_LIBS.lock().expect("Nvidia library lock poisoned");
+    if guard.is_none() {
+        *guard = init_nvidia_libs();
+    }
+    guard.clone()
+}
+
+#[cfg(all(feature = "nvidia", test))]
+fn get_nvidia_libs() -> Option<NvidiaLibs> {
+    None
+}
+
+#[cfg(all(feature = "nvidia", not(test)))]
+fn init_nvidia_libs() -> Option<NvidiaLibs> {
+    match Nvml::init() {
+        Ok(nvml) => {
+            let disable_nvapi = Config::load()
+                .ok()
+                .flatten()
+                .and_then(|config| config.daemon.disable_nvapi);
+
+            info!("Nvidia management library loaded");
+            let nvapi = if disable_nvapi == Some(true) {
+                info!("NvAPI support is disabled");
+                None
+            } else {
+                NvApi::new()
+                    .inspect(|_| info!("NvAPI library loaded"))
+                    .inspect_err(|err| warn!("could not load NvAPI library: {err:#}"))
+                    .ok()
+                    .map(Arc::new)
+            };
+
+            Some(NvidiaLibs {
+                nvapi,
+                nvml: Arc::new(nvml),
+            })
+        }
+        Err(err) => {
+            error!("could not load Nvidia management library: {err}");
+            None
+        }
+    }
+}
+
+#[cfg(all(feature = "nvidia", not(test)))]
+pub(crate) fn release_nvidia_libs() {
+    let libs = NVIDIA_LIBS
+        .lock()
+        .expect("Nvidia library lock poisoned")
+        .take();
+    drop(libs);
+}
+
+#[cfg(any(not(feature = "nvidia"), test))]
+pub(crate) fn release_nvidia_libs() {}
 
 pub(crate) fn init_controller(
     path: PathBuf,
     pci_db: &pciid_parser::Database,
 ) -> anyhow::Result<Box<dyn GpuController>> {
-    #[cfg(not(feature = "nvidia"))]
-    let _ = NVML;
-
     let uevent_path = path.join("uevent");
     let uevent = fs::read_to_string(uevent_path).context("Could not read 'uevent'")?;
     let mut uevent_map = parse_uevent(&uevent);
@@ -265,8 +336,8 @@ pub(crate) fn init_controller(
         }
         #[cfg(feature = "nvidia")]
         "nvidia" => {
-            if let Some((nvml, nvapi)) = NVML.as_ref() {
-                match NvidiaGpuController::new(common.clone(), nvml, nvapi.as_ref().as_ref()) {
+            if let Some(libs) = get_nvidia_libs() {
+                match NvidiaGpuController::new(common.clone(), libs.nvml, libs.nvapi) {
                     Ok(controller) => {
                         return Ok(Box::new(controller));
                     }
@@ -292,6 +363,23 @@ pub(crate) fn init_controller(
         AmdGpuController::new_from_path(common, None)
             .context("Could initialize fallback controller")?,
     ))
+}
+
+pub(crate) fn read_controller_identity(path: &Path) -> anyhow::Result<(String, String)> {
+    let uevent_path = path.join("uevent");
+    let uevent = fs::read_to_string(uevent_path).context("Could not read 'uevent'")?;
+    let uevent_map = parse_uevent(&uevent);
+
+    let pci_slot_name = uevent_map
+        .get("PCI_SLOT_NAME")
+        .context("PCI_SLOT_NAME entry missing in 'uevent'")?
+        .to_string();
+    let driver = uevent_map
+        .get("DRIVER")
+        .context("DRIVER entry missing in 'uevent'")?
+        .to_string();
+
+    Ok((pci_slot_name, driver))
 }
 
 fn parse_uevent(data: &str) -> HashMap<&str, &str> {

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -39,6 +39,7 @@ use std::{
     collections::{BTreeMap, HashMap, btree_map::Entry},
     fmt::Write,
     rc::Rc,
+    sync::Arc,
     time::{Duration, Instant},
 };
 use tokio::{select, sync::Notify, time::sleep};
@@ -52,12 +53,12 @@ const SUPPORTED_UTIL_TYPES: &[ProcessUtilizationType] = &[
 ];
 
 pub struct NvidiaGpuController {
-    nvml: &'static Nvml,
+    nvml: Arc<Nvml>,
     common: CommonControllerInfo,
     fan_control_handle: RefCell<Option<FanControlHandle>>,
     initial_target_temp: Option<u32>,
 
-    nvapi: Option<(&'static NvApi, NvPhysicalGpuHandle)>,
+    nvapi: Option<(Arc<NvApi>, NvPhysicalGpuHandle)>,
     driver_handle: Option<DriverHandle>,
     nvapi_thermals_mask: Option<i32>,
 
@@ -75,8 +76,8 @@ pub struct NvidiaGpuController {
 impl NvidiaGpuController {
     pub fn new(
         common: CommonControllerInfo,
-        nvml: &'static Nvml,
-        nvapi: Option<&'static NvApi>,
+        nvml: Arc<Nvml>,
+        nvapi: Option<Arc<NvApi>>,
     ) -> anyhow::Result<Self> {
         let device = nvml
             .device_by_pci_bus_id(common.pci_slot_name.as_str())
@@ -205,7 +206,7 @@ impl NvidiaGpuController {
         let notify = Rc::new(Notify::new());
         let task_notify = notify.clone();
 
-        let nvml = self.nvml;
+        let nvml = self.nvml.clone();
         let pci_slot_id = self.common.pci_slot_name.clone();
         debug!("spawning new fan control task");
 

--- a/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
@@ -296,7 +296,9 @@ impl NvApi {
 impl Drop for NvApi {
     fn drop(&mut self) {
         unsafe {
-            let unload = self.query_interface(QUERY_NVAPI_UNLOAD).unwrap();
+            let Ok(unload) = self.query_interface(QUERY_NVAPI_UNLOAD) else {
+                return;
+            };
             let unload: unsafe extern "C" fn() -> NvAPI_Status = transmute(unload);
             unload();
         }

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -5,12 +5,17 @@ use super::{
 };
 #[cfg(feature = "display-info")]
 use crate::server::display;
+use crate::system::run_command;
 use crate::{
     bindings::intel::IntelDrm,
     config::Config,
-    server::{ClientContext, gpu_controller::init_controller, profiles, system::DAEMON_VERSION},
+    server::{
+        ClientContext,
+        gpu_controller::{init_controller, read_controller_identity, release_nvidia_libs},
+        profiles,
+        system::DAEMON_VERSION,
+    },
 };
-use crate::{server::gpu_controller::NvidiaLibs, system::run_command};
 use amdgpu_sysfs::gpu_handle::{
     PerformanceLevel, PowerLevelKind, power_profile_mode::PowerProfileModesTable,
 };
@@ -28,15 +33,11 @@ use lact_schema::{
 use libdrm_amdgpu_sys::LibDrmAmdgpu;
 use libflate::gzip;
 use nix::libc;
-#[cfg(all(not(test), feature = "nvidia"))]
-use nvml_wrapper::Nvml;
 use pciid_parser::Database;
 use serde_json::json;
-#[cfg(all(not(test), feature = "nvidia"))]
-use std::sync::Arc;
 use std::{
     cell::{Cell, RefCell},
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     env,
     fs::{self, File, Permissions},
     io::{BufWriter, Cursor, Write},
@@ -48,7 +49,7 @@ use std::{
 };
 use tokio::{
     process::Command,
-    sync::{RwLock, RwLockReadGuard, mpsc, oneshot},
+    sync::{Mutex, RwLock, RwLockReadGuard, mpsc, oneshot},
     task::JoinHandle,
     time::sleep,
 };
@@ -92,10 +93,33 @@ mod polkit_actions {
 type ProfileHolds = Rc<RefCell<Vec<(u64, Rc<str>, mpsc::Sender<()>)>>>;
 type ProfileHoldSnapshot = Rc<RefCell<Option<(Option<Rc<str>>, bool)>>>;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum GpuManagementStatus {
+    Detached,
+    Attaching,
+}
+
+#[derive(Clone, Debug)]
+struct ManagedGpuState {
+    id: String,
+    pci_slot_name: String,
+    list_index: usize,
+    status: GpuManagementStatus,
+}
+
+#[derive(Debug)]
+struct ControllerCandidate {
+    path: PathBuf,
+    driver: String,
+}
+
 #[derive(Clone)]
 pub struct Handler {
     pub config: Rc<RwLock<Config>>,
     gpu_controllers: Rc<RwLock<BTreeMap<String, DynGpuController>>>,
+    gpu_management_states: Rc<RwLock<BTreeMap<String, ManagedGpuState>>>,
+    gpu_management_lock: Rc<Mutex<()>>,
+    drm_base_path: Rc<PathBuf>,
     confirm_config_tx: Rc<RefCell<Option<oneshot::Sender<ConfirmCommand>>>>,
     pub config_last_saved: Rc<Cell<Instant>>,
     profile_watcher_tx: Rc<RefCell<Option<mpsc::Sender<ProfileWatcherCommand>>>>,
@@ -191,6 +215,9 @@ impl<'a> Handler {
 
         let handler = Self {
             gpu_controllers: Rc::new(RwLock::new(controllers)),
+            gpu_management_states: Rc::new(RwLock::new(BTreeMap::new())),
+            gpu_management_lock: Rc::new(Mutex::new(())),
+            drm_base_path: Rc::new(base_path.to_path_buf()),
             config: Rc::new(RwLock::new(config)),
             confirm_config_tx: Rc::new(RefCell::new(None)),
             config_last_saved: Rc::new(Cell::new(Instant::now())),
@@ -226,44 +253,290 @@ impl<'a> Handler {
     }
 
     pub async fn apply_current_config(&self) -> anyhow::Result<()> {
+        let unavailable_ids = self
+            .gpu_management_states
+            .read()
+            .await
+            .keys()
+            .cloned()
+            .collect();
         let config = self.config.read().await;
         let controllers = self.gpu_controllers.read().await;
-        apply_config_to_controllers(&controllers, &config).await
+        apply_config_to_controllers(&controllers, &config, &unavailable_ids).await
     }
 
     pub async fn reload_gpus(&self) {
-        let mut controllers_guard = self.gpu_controllers.write().await;
-        let config = self.config.read().await;
+        let _management_guard = self.gpu_management_lock.lock().await;
+        if let Err(err) = self.reconcile_gpus().await {
+            error!("could not reload GPU controllers: {err:#}");
+        }
+    }
 
-        let base_path = drm_base_path();
+    async fn reconcile_gpus(&self) -> anyhow::Result<()> {
+        let candidates = discover_controller_candidates(&self.drm_base_path)?;
+        let management_states = self.gpu_management_states.read().await;
+        let detached_slots: BTreeSet<String> = management_states
+            .values()
+            .filter(|state| state.status == GpuManagementStatus::Detached)
+            .map(|state| state.pci_slot_name.clone())
+            .collect();
+        let nvidia_release_blocked = management_states.values().any(|state| {
+            state.status == GpuManagementStatus::Detached
+                && candidates
+                    .get(&state.pci_slot_name)
+                    .is_some_and(|candidate| candidate.driver == "nvidia")
+        });
+        drop(management_states);
+
+        let removed_controllers = {
+            let mut controllers = self.gpu_controllers.write().await;
+            let removed_ids: Vec<String> = controllers
+                .iter()
+                .filter_map(|(id, controller)| {
+                    let info = controller.controller_info();
+                    let should_keep =
+                        candidates
+                            .get(&info.pci_slot_name)
+                            .is_some_and(|candidate| {
+                                candidate.driver == info.driver && candidate.path == info.sysfs_path
+                            })
+                            && !detached_slots.contains(&info.pci_slot_name)
+                            && !(nvidia_release_blocked && info.driver == "nvidia");
+                    (!should_keep).then(|| id.clone())
+                })
+                .collect();
+
+            removed_ids
+                .into_iter()
+                .filter_map(|id| controllers.remove(&id).map(|controller| (id, controller)))
+                .collect::<Vec<_>>()
+        };
+
+        for (id, controller) in removed_controllers {
+            info!("removing controller for unavailable GPU {id}");
+            controller.cleanup().await;
+        }
+
+        if !self
+            .gpu_controllers
+            .read()
+            .await
+            .values()
+            .any(|controller| controller.controller_info().driver == "nvidia")
+        {
+            release_nvidia_libs();
+        }
+
+        let active_slots: BTreeSet<String> = self
+            .gpu_controllers
+            .read()
+            .await
+            .values()
+            .map(|controller| controller.controller_info().pci_slot_name.clone())
+            .collect();
         let pci_db = read_pci_db();
-        match load_controllers(&base_path, &pci_db) {
-            Ok(new_controllers) => {
-                info!(
-                    "GPU list reloaded with {} devices, reapplying configuration",
-                    new_controllers.len()
-                );
+        let mut added_controllers = Vec::new();
 
-                for old_controller in controllers_guard.values() {
-                    old_controller.cleanup().await;
-                    let _ = old_controller.reset_clocks();
-                }
-
-                *controllers_guard = new_controllers;
-
-                match apply_config_to_controllers(&controllers_guard, &config).await {
-                    Ok(()) => {
-                        info!("configuration applied");
-                    }
-                    Err(err) => {
-                        error!("could not reapply config: {err:#}");
-                    }
-                }
+        for (pci_slot_name, candidate) in candidates {
+            if active_slots.contains(&pci_slot_name)
+                || detached_slots.contains(&pci_slot_name)
+                || (nvidia_release_blocked && candidate.driver == "nvidia")
+            {
+                continue;
             }
-            Err(err) => {
-                error!("could not load GPU controllers: {err:#}");
+
+            match init_controller(candidate.path.clone(), &pci_db) {
+                Ok(controller) => {
+                    let info = controller.controller_info();
+                    let id = info.build_id();
+                    info!(
+                        "initialized {} controller for GPU {id} at '{}'",
+                        info.driver,
+                        info.sysfs_path.display()
+                    );
+                    added_controllers.push((id, controller));
+                }
+                Err(err) => {
+                    error!(
+                        "could not initialize GPU controller at '{}': {err:#}",
+                        candidate.path.display()
+                    );
+                }
             }
         }
+
+        let added_ids: Vec<String> = added_controllers.iter().map(|(id, _)| id.clone()).collect();
+        if !added_controllers.is_empty() {
+            let mut controllers = self.gpu_controllers.write().await;
+            controllers.extend(added_controllers);
+        }
+
+        if !added_ids.is_empty() {
+            let config = self.config.read().await;
+            let controllers = self.gpu_controllers.read().await;
+            apply_config_to_selected_controllers(&controllers, &config, &added_ids).await?;
+        }
+
+        let active_slots: BTreeSet<String> = self
+            .gpu_controllers
+            .read()
+            .await
+            .values()
+            .map(|controller| controller.controller_info().pci_slot_name.clone())
+            .collect();
+        self.gpu_management_states.write().await.retain(|_, state| {
+            state.status == GpuManagementStatus::Detached
+                || !active_slots.contains(&state.pci_slot_name)
+        });
+
+        info!(
+            "GPU list reloaded with {} managed devices",
+            self.gpu_controllers.read().await.len()
+        );
+        Ok(())
+    }
+
+    pub async fn detach_gpu(&self, selector: Option<&str>) -> anyhow::Result<String> {
+        let _management_guard = self.gpu_management_lock.lock().await;
+
+        let selected_id = {
+            let controllers = self.gpu_controllers.read().await;
+            match selector {
+                Some(selector) => find_controller_id(&controllers, selector),
+                None if controllers.len() == 1 => controllers.keys().next().cloned(),
+                None if controllers.is_empty() => None,
+                None => bail!("Multiple GPUs are managed; specify one with --gpu-id"),
+            }
+        };
+
+        let Some(selected_id) = selected_id else {
+            let state = {
+                let states = self.gpu_management_states.read().await;
+                select_managed_state(&states, selector)?.context("GPU not found")?
+            };
+            self.gpu_management_states
+                .write()
+                .await
+                .entry(state.id.clone())
+                .and_modify(|state| state.status = GpuManagementStatus::Detached);
+            return Ok(state.id);
+        };
+
+        let (id, pci_slot_name, list_index, driver, controller, paused_controllers) = {
+            let mut controllers = self.gpu_controllers.write().await;
+            let list_indices = controllers
+                .keys()
+                .enumerate()
+                .map(|(index, id)| (id.clone(), index))
+                .collect::<BTreeMap<_, _>>();
+            let list_index = *list_indices
+                .get(&selected_id)
+                .with_context(|| format!("Controller '{selected_id}' not found"))?;
+            let driver = controllers
+                .get(&selected_id)
+                .with_context(|| format!("Controller '{selected_id}' not found"))?
+                .controller_info()
+                .driver
+                .clone();
+            let controller = controllers
+                .remove(&selected_id)
+                .with_context(|| format!("Controller '{selected_id}' not found"))?;
+            let pci_slot_name = controller.controller_info().pci_slot_name.clone();
+            let paused_ids = if driver == "nvidia" {
+                controllers
+                    .iter()
+                    .filter(|(_, controller)| controller.controller_info().driver == "nvidia")
+                    .map(|(id, _)| id.clone())
+                    .collect::<Vec<_>>()
+            } else {
+                Vec::new()
+            };
+            let paused_controllers: Vec<(String, usize, DynGpuController)> = paused_ids
+                .into_iter()
+                .filter_map(|id| {
+                    let index = *list_indices.get(&id)?;
+                    controllers
+                        .remove(&id)
+                        .map(|controller| (id, index, controller))
+                })
+                .collect();
+
+            (
+                selected_id,
+                pci_slot_name,
+                list_index,
+                driver,
+                controller,
+                paused_controllers,
+            )
+        };
+
+        {
+            let mut states = self.gpu_management_states.write().await;
+            states.insert(
+                id.clone(),
+                ManagedGpuState {
+                    id: id.clone(),
+                    pci_slot_name: pci_slot_name.clone(),
+                    list_index,
+                    status: GpuManagementStatus::Detached,
+                },
+            );
+            for (paused_id, list_index, paused_controller) in &paused_controllers {
+                states.insert(
+                    paused_id.clone(),
+                    ManagedGpuState {
+                        id: paused_id.clone(),
+                        pci_slot_name: paused_controller.controller_info().pci_slot_name.clone(),
+                        list_index: *list_index,
+                        status: GpuManagementStatus::Attaching,
+                    },
+                );
+            }
+        }
+
+        info!("detaching GPU {id} at {pci_slot_name} from LACT management");
+        let disable_clocks_cleanup = self.config.read().await.daemon.disable_clocks_cleanup;
+        cleanup_controller(&id, controller.as_ref(), disable_clocks_cleanup).await;
+        drop(controller);
+
+        for (paused_id, _, paused_controller) in paused_controllers {
+            info!("temporarily releasing Nvidia controller for GPU {paused_id}");
+            paused_controller.cleanup().await;
+        }
+        if driver == "nvidia" {
+            release_nvidia_libs();
+        }
+        info!("detached GPU {id} from LACT management");
+
+        Ok(id)
+    }
+
+    pub async fn attach_gpu(&self, selector: Option<&str>) -> anyhow::Result<String> {
+        let _management_guard = self.gpu_management_lock.lock().await;
+
+        let state = {
+            let states = self.gpu_management_states.read().await;
+            select_managed_state(&states, selector)?
+        };
+        let Some(state) = state else {
+            let controllers = self.gpu_controllers.read().await;
+            return select_controller_id(&controllers, selector).context("No detached GPU found");
+        };
+
+        self.gpu_management_states
+            .write()
+            .await
+            .entry(state.id.clone())
+            .and_modify(|state| state.status = GpuManagementStatus::Attaching);
+
+        info!(
+            "attaching GPU {} at {} to LACT management",
+            state.id, state.pci_slot_name
+        );
+        self.reconcile_gpus().await?;
+
+        Ok(state.id)
     }
 
     async fn stop_profile_watcher(&self) {
@@ -436,6 +709,15 @@ impl<'a> Handler {
         }
 
         entries
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn controller_address(&self, id: &str) -> Option<usize> {
+        self.gpu_controllers
+            .read()
+            .await
+            .get(id)
+            .map(|controller| std::ptr::from_ref(controller.as_ref()).cast::<()>() as usize)
     }
 
     pub async fn get_device_info(
@@ -1217,20 +1499,7 @@ impl<'a> Handler {
 
         let controllers = self.gpu_controllers.read().await;
         for (id, controller) in controllers.iter() {
-            if !disable_clocks_cleanup {
-                debug!("resetting clocks table");
-                if let Err(err) = controller.reset_clocks() {
-                    error!("could not reset the clocks table: {err}");
-                }
-            }
-
-            controller.reset_pmfw_settings();
-
-            if let Err(err) = controller.apply_config(&GpuConfig::default()).await {
-                error!("Could not reset settings for controller {id}: {err:#}");
-            }
-
-            controller.cleanup().await;
+            cleanup_controller(id, controller.as_ref(), disable_clocks_cleanup).await;
         }
     }
 
@@ -1269,6 +1538,7 @@ impl<'a> Handler {
 async fn apply_config_to_controllers(
     controllers: &BTreeMap<String, Box<dyn GpuController>>,
     config: &Config,
+    unavailable_ids: &BTreeSet<String>,
 ) -> anyhow::Result<()> {
     let gpus = config.gpus()?;
     for (id, gpu_config) in gpus {
@@ -1277,12 +1547,114 @@ async fn apply_config_to_controllers(
             if let Err(err) = controller.apply_config(gpu_config).await {
                 error!("could not apply existing config for gpu {id}: {err:#}");
             }
-        } else {
+        } else if !unavailable_ids.contains(id) {
             warn!("could not find GPU with id {id} defined in configuration");
         }
     }
 
     Ok(())
+}
+
+async fn apply_config_to_selected_controllers(
+    controllers: &BTreeMap<String, Box<dyn GpuController>>,
+    config: &Config,
+    selected_ids: &[String],
+) -> anyhow::Result<()> {
+    let gpus = config.gpus()?;
+    for id in selected_ids {
+        let Some(gpu_config) = gpus.get(id) else {
+            continue;
+        };
+        let Some(controller) = controllers.get(id) else {
+            continue;
+        };
+
+        debug!("applying config {gpu_config:#?} to controller {id}");
+        if let Err(err) = controller.apply_config(gpu_config).await {
+            error!("could not apply existing config for gpu {id}: {err:#}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn cleanup_controller(
+    id: &str,
+    controller: &dyn GpuController,
+    disable_clocks_cleanup: bool,
+) {
+    if !disable_clocks_cleanup {
+        debug!("resetting clocks table for controller {id}");
+        if let Err(err) = controller.reset_clocks() {
+            error!("could not reset the clocks table for controller {id}: {err}");
+        }
+    }
+
+    controller.reset_pmfw_settings();
+
+    if let Err(err) = controller.apply_config(&GpuConfig::default()).await {
+        error!("Could not reset settings for controller {id}: {err:#}");
+    }
+
+    controller.cleanup().await;
+}
+
+fn find_controller_id(
+    controllers: &BTreeMap<String, DynGpuController>,
+    selector: &str,
+) -> Option<String> {
+    if let Ok(index) = selector.parse::<usize>() {
+        return controllers.keys().nth(index).cloned();
+    }
+
+    controllers
+        .contains_key(selector)
+        .then(|| selector.to_owned())
+}
+
+fn select_controller_id(
+    controllers: &BTreeMap<String, DynGpuController>,
+    selector: Option<&str>,
+) -> anyhow::Result<String> {
+    match selector {
+        Some(selector) => find_controller_id(controllers, selector)
+            .with_context(|| format!("GPU '{selector}' not found")),
+        None if controllers.len() == 1 => Ok(controllers.keys().next().unwrap().clone()),
+        None if controllers.is_empty() => bail!("No managed GPUs found"),
+        None => bail!("Multiple GPUs are managed; specify one with --gpu-id"),
+    }
+}
+
+fn select_managed_state(
+    states: &BTreeMap<String, ManagedGpuState>,
+    selector: Option<&str>,
+) -> anyhow::Result<Option<ManagedGpuState>> {
+    if let Some(selector) = selector {
+        if let Ok(index) = selector.parse::<usize>() {
+            let matches = states
+                .values()
+                .filter(|state| state.list_index == index)
+                .collect::<Vec<_>>();
+            return match matches.as_slice() {
+                [state] => Ok(Some((*state).clone())),
+                [] => Ok(None),
+                _ => bail!("Multiple unavailable GPUs used index {index}; specify the full GPU ID"),
+            };
+        }
+
+        return Ok(states.get(selector).cloned());
+    }
+
+    let detached = states
+        .values()
+        .filter(|state| state.status == GpuManagementStatus::Detached)
+        .collect::<Vec<_>>();
+    match detached.as_slice() {
+        [state] => Ok(Some((*state).clone())),
+        [] if states.len() == 1 => Ok(states.values().next().cloned()),
+        [] if states.is_empty() => Ok(None),
+        _ => bail!("Multiple GPUs are unavailable; specify one with --gpu-id"),
+    }
 }
 
 #[cfg(all(test, not(miri)))]
@@ -1316,48 +1688,6 @@ pub(crate) fn read_pci_db() -> Database {
     })
 }
 
-#[cfg(any(test, not(feature = "nvidia")))]
-pub(crate) static NVML: LazyLock<Option<NvidiaLibs>> = LazyLock::new(|| None);
-
-#[cfg(all(not(test), feature = "nvidia"))]
-// SAFETY: We use global LazyLock to make sure it's safe.
-// Loading of shared libaries is unsafe
-// https://docs.rs/libloading/0.8.8/libloading/struct.Library.html#method.new
-#[allow(unused_unsafe)]
-pub(crate) static NVML: LazyLock<Option<NvidiaLibs>> =
-    LazyLock::new(|| match unsafe { Nvml::init() } {
-        Ok(nvml) => {
-            use crate::server::gpu_controller::NvApi;
-
-            // The config has to be re-read here, because a LazyLock cannot capture external variables into the init closure
-            let disable_nvapi = Config::load()
-                .ok()
-                .flatten()
-                .and_then(|config| config.daemon.disable_nvapi);
-
-            info!("Nvidia management library loaded");
-            let nvapi = if disable_nvapi == Some(true) {
-                info!("NvAPI support is disabled");
-                None
-            } else {
-                NvApi::new()
-                    .inspect(|_| {
-                        info!("NvAPI library loaded");
-                    })
-                    .inspect_err(|err| {
-                        warn!("could not load NvAPI library: {err:#}");
-                    })
-                    .ok()
-            };
-
-            Some((Arc::new(nvml), Arc::new(nvapi)))
-        }
-        Err(err) => {
-            error!("could not load Nvidia management library: {err}");
-            None
-        }
-    });
-
 pub(crate) static AMD_DRM: LazyLock<Option<LibDrmAmdgpu>> = LazyLock::new(|| {
     // SAFETY: We use global LazyLock to make sure it's safe.
     #[allow(unused_unsafe)]
@@ -1389,6 +1719,50 @@ pub(crate) static INTEL_DRM: LazyLock<Option<IntelDrm>> = LazyLock::new(|| {
         }
     }
 });
+
+fn discover_controller_candidates(
+    base_path: &Path,
+) -> anyhow::Result<BTreeMap<String, ControllerCandidate>> {
+    let mut candidates = BTreeMap::new();
+
+    for entry in base_path
+        .read_dir()
+        .map_err(|error| anyhow!("Failed to read sysfs: {error}"))?
+    {
+        let entry = entry?;
+        let name = entry
+            .file_name()
+            .into_string()
+            .map_err(|_| anyhow!("non-utf path"))?;
+        if !name.starts_with("card") || name.contains('-') {
+            continue;
+        }
+
+        let device_path = entry.path().join("device");
+        match read_controller_identity(&device_path) {
+            Ok((pci_slot_name, driver)) => {
+                let candidate = ControllerCandidate {
+                    path: device_path,
+                    driver,
+                };
+                if candidates
+                    .insert(pci_slot_name.clone(), candidate)
+                    .is_some()
+                {
+                    warn!("multiple DRM cards found for GPU at {pci_slot_name}");
+                }
+            }
+            Err(err) => {
+                error!(
+                    "could not identify GPU controller at '{}': {err:#}",
+                    device_path.display()
+                );
+            }
+        }
+    }
+
+    Ok(candidates)
+}
 
 /// `sysfs_only` disables initialization of any external data sources, such as libdrm and nvml
 fn load_controllers(

--- a/lact-daemon/src/tests/mod.rs
+++ b/lact-daemon/src/tests/mod.rs
@@ -126,3 +126,132 @@ async fn apply_settings() {
         }
     }
 }
+
+#[tokio::test(flavor = "local")]
+#[cfg_attr(miri, ignore)]
+async fn detach_and_attach_nvidia_gpu_without_recreating_other_vendors() {
+    init_tracing();
+
+    let snapshots = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../tests/snapshots/amd");
+    let drm_dir = tempdir().unwrap();
+    let first_card = drm_dir.path().join("card0");
+    let second_card = drm_dir.path().join("card1");
+    let third_card = drm_dir.path().join("card2");
+    copy_dir(&snapshots.join("phoenix/card1"), &first_card);
+    copy_dir(&snapshots.join("rx6600/card1"), &second_card);
+    copy_dir(&snapshots.join("rx580/card0"), &third_card);
+    set_driver(&first_card, "nvidia");
+    set_driver(&second_card, "nvidia");
+
+    let handler = Handler::with_base_path(drm_dir.path(), Config::default(), &read_pci_db())
+        .await
+        .unwrap();
+    let devices = handler.list_devices().await;
+    assert_eq!(devices.len(), 3);
+
+    let detached_id = devices
+        .iter()
+        .find(|device| device.id.ends_with("0000:64:00.0"))
+        .unwrap()
+        .id
+        .clone();
+    let detached_index = devices
+        .iter()
+        .position(|device| device.id == detached_id)
+        .unwrap()
+        .to_string();
+    let paused_id = devices
+        .iter()
+        .find(|device| device.id.ends_with("0000:12:00.0"))
+        .unwrap()
+        .id
+        .clone();
+    let retained_id = devices
+        .iter()
+        .find(|device| device.id != detached_id && device.id != paused_id)
+        .unwrap()
+        .id
+        .clone();
+    let retained_address = handler.controller_address(&retained_id).await.unwrap();
+
+    assert!(handler.detach_gpu(None).await.is_err());
+    let (first_detach, second_detach, ()) = tokio::join!(
+        handler.detach_gpu(Some(&detached_index)),
+        handler.detach_gpu(Some(&detached_id)),
+        handler.reload_gpus()
+    );
+    assert_eq!(first_detach.unwrap(), detached_id);
+    assert_eq!(second_detach.unwrap(), detached_id);
+    assert_eq!(
+        handler
+            .list_devices()
+            .await
+            .into_iter()
+            .map(|device| device.id)
+            .collect::<Vec<_>>(),
+        vec![retained_id.clone()]
+    );
+
+    handler.reload_gpus().await;
+    assert_eq!(
+        handler.controller_address(&retained_id).await,
+        Some(retained_address)
+    );
+
+    fs::remove_dir_all(&first_card).unwrap();
+    handler.reload_gpus().await;
+    assert!(
+        handler
+            .list_devices()
+            .await
+            .iter()
+            .any(|device| device.id == paused_id)
+    );
+    let (first_attach, second_attach, ()) = tokio::join!(
+        handler.attach_gpu(Some(&detached_index)),
+        handler.attach_gpu(Some(&detached_id)),
+        handler.reload_gpus()
+    );
+    assert_eq!(first_attach.unwrap(), detached_id);
+    assert_eq!(second_attach.unwrap(), detached_id);
+    assert_eq!(handler.list_devices().await.len(), 2);
+
+    copy_dir(&snapshots.join("phoenix/card1"), &first_card);
+    set_driver(&first_card, "nvidia");
+    handler.reload_gpus().await;
+    let attached_devices = handler.list_devices().await;
+    assert_eq!(attached_devices.len(), 3);
+    assert!(
+        attached_devices
+            .iter()
+            .any(|device| device.id == detached_id)
+    );
+    assert_eq!(
+        handler.controller_address(&retained_id).await,
+        Some(retained_address)
+    );
+    assert_eq!(
+        handler.attach_gpu(Some(&detached_index)).await.unwrap(),
+        detached_id
+    );
+}
+
+fn copy_dir(source: &std::path::Path, destination: &std::path::Path) {
+    fs::create_dir(destination).unwrap();
+    for entry in fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let target = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir(&entry.path(), &target);
+        } else {
+            fs::copy(entry.path(), target).unwrap();
+        }
+    }
+}
+
+fn set_driver(card_path: &std::path::Path, driver: &str) {
+    let uevent_path = card_path.join("device/uevent");
+    let uevent = fs::read_to_string(&uevent_path).unwrap();
+    let updated = uevent.replace("DRIVER=amdgpu", &format!("DRIVER={driver}"));
+    fs::write(uevent_path, updated).unwrap();
+}

--- a/lact-schema/src/args/cli.rs
+++ b/lact-schema/src/args/cli.rs
@@ -14,6 +14,10 @@ pub enum CliCommand {
     /// List GPUs
     #[clap(alias = "list-gpus")]
     List,
+    /// Release a GPU from LACT management
+    Detach,
+    /// Restore LACT management for a GPU
+    Attach,
     /// Show GPU info
     Info,
     /// Show GPU stats

--- a/lact-schema/src/request.rs
+++ b/lact-schema/src/request.rs
@@ -12,6 +12,14 @@ use serde::{Deserialize, Serialize};
 pub enum Request<'a> {
     Ping,
     ListDevices,
+    DetachGpu {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<&'a str>,
+    },
+    AttachGpu {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<&'a str>,
+    },
     SystemInfo,
     DeviceInfo {
         id: &'a str,
@@ -211,6 +219,21 @@ mod tests {
             },
             serde_json::from_str(r#"{"command": "set_clocks_value", "args": {"id": "asd", "command": {"type": "max_core_clock", "value": 2000}}}"#)
                 .unwrap()
+        );
+    }
+
+    #[test]
+    fn serialize_gpu_management_requests() {
+        assert_eq!(
+            serde_json::to_string(&Request::DetachGpu {
+                id: Some("10DE:2B85-10DE:2057-0000:03:00.0")
+            })
+            .unwrap(),
+            r#"{"command":"detach_gpu","args":{"id":"10DE:2B85-10DE:2057-0000:03:00.0"}}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&Request::AttachGpu { id: None }).unwrap(),
+            r#"{"command":"attach_gpu","args":{}}"#
         );
     }
 }


### PR DESCRIPTION
Problem: Releasing one GPU for driver unbind or VFIO requires stopping `lactd`, which resets the settings of all managed GPUs to their defaults. (the current `lactd`'s behavior)

Fix: Add per-GPU `detach` and `attach` commands that release only the selected GPU and reapply its saved configuration when it re-attaches.

Example usage:

```
lact cli --gpu-id 1 detach # Or: lact cli --gpu-id 10DE:2B85-10DE:2057-0000:03:00.0 detach
# Pass it to VFIO driver, and VM via virsh
# ... (playing Windows games)
# Reclaim it from VM via virsh, then rebind it to NVIDIA
lact cli --gpu-id 1 attach # Or: lact cli --gpu-id 10DE:2B85-10DE:2057-0000:03:00.0 attach
# No other GPU will have intermediate and brief reset in their LACT settings.
```

(otherwise, just make `lactd` not to reset settings for all GPUs when the service is just stopped (normally), which can be more desirable and undesirable by the perspectives)