### PR TITLE
feat: add per-memory-chip temperatures for Nvidia GDDR6X/GDDR7

### DIFF
--- a/lact-daemon/src/server/gpu_controller/amd.rs
+++ b/lact-daemon/src/server/gpu_controller/amd.rs
@@ -16,6 +16,7 @@ use amdgpu_sysfs::{
 };
 use anyhow::{Context, anyhow, bail};
 use futures::{FutureExt, future::LocalBoxFuture};
+use indexmap::IndexMap;
 use lact_schema::{
     ActivePowerStates, AmdCacheInstance, AmdIpInfo, CacheInfo, CacheType, ClocksInfo,
     ClockspeedStats, DeviceApiInfo, DeviceFlag, DeviceInfo, DeviceStats, DeviceType, DrmInfo,
@@ -953,7 +954,7 @@ impl GpuController for AmdGpuController {
             .map(|percent| (f64::from(percent) * 2.55) as u32)
             .or_else(|| self.hw_mon_and_then(HwMon::get_fan_min_pwm).map(u32::from));
 
-        let mut temps: HashMap<String, TemperatureEntry> = HashMap::new();
+        let mut temps: IndexMap<String, TemperatureEntry> = IndexMap::new();
 
         if let Ok(hwmon) = self.first_hw_mon() {
             temps = hwmon
@@ -968,6 +969,8 @@ impl GpuController for AmdGpuController {
                     (name, entry)
                 })
                 .collect();
+
+            temps.sort_by(|a, _, b, _| a.cmp(b));
         }
 
         let mut power_sensors = HashMap::new();

--- a/lact-daemon/src/server/gpu_controller/intel.rs
+++ b/lact-daemon/src/server/gpu_controller/intel.rs
@@ -11,6 +11,7 @@ use crate::{
 use amdgpu_sysfs::{gpu_handle::power_profile_mode::PowerProfileModesTable, hw_mon::Temperature};
 use anyhow::{Context, anyhow, bail};
 use futures::future::LocalBoxFuture;
+use indexmap::IndexMap;
 use lact_schema::{
     ClocksInfo, ClocksTable, ClockspeedStats, DeviceApiInfo, DeviceInfo, DeviceStats, DeviceType,
     DrmInfo, DrmMemoryInfo, FanStats, IntelClocksTable, IntelDrmInfo, LinkInfo, PowerState,
@@ -356,7 +357,7 @@ impl IntelGpuController {
         }
     }
 
-    fn get_temperatures(&self) -> HashMap<String, TemperatureEntry> {
+    fn get_temperatures(&self) -> IndexMap<String, TemperatureEntry> {
         self.read_hwmon_files::<f32>("temp", "_input")
             .map(|(temp, file)| {
                 let mut key = None;

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -788,7 +788,7 @@ impl GpuController for NvidiaGpuController {
     fn get_stats(&self, gpu_config: Option<&GpuConfig>) -> DeviceStats {
         let device = self.device();
 
-        let mut temps = HashMap::new();
+        let mut temps = IndexMap::new();
 
         if let Ok(temp) = device.temperature(TemperatureSensor::Gpu) {
             let crit = device
@@ -854,6 +854,28 @@ impl GpuController for NvidiaGpuController {
                                 display_only: true,
                             },
                         );
+                    }
+
+                    match nvapi.read_vram_temps(*handle, vram_type) {
+                        Ok(sensors) => {
+                            for (i, value) in sensors.into_iter().enumerate() {
+                                temps.insert(
+                                    format!("VRAM Chip {}", i + 1),
+                                    TemperatureEntry {
+                                        value: Temperature {
+                                            current: Some(value as f32),
+                                            crit: None,
+                                            crit_hyst: None,
+                                        },
+                                        primary: false,
+                                        display_only: true,
+                                    },
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            warn!("could not read VRAM sensors: {err:#}");
+                        }
                     }
                 }
 

--- a/lact-daemon/src/server/gpu_controller/nvidia.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia.rs
@@ -858,9 +858,9 @@ impl GpuController for NvidiaGpuController {
 
                     match nvapi.read_vram_temps(*handle, vram_type) {
                         Ok(sensors) => {
-                            for (i, value) in sensors.into_iter().enumerate() {
+                            for (label, value) in sensors {
                                 temps.insert(
-                                    format!("VRAM Chip {}", i + 1),
+                                    format!("VRAM Chip {label}"),
                                     TemperatureEntry {
                                         value: Temperature {
                                             current: Some(value as f32),

--- a/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
@@ -243,7 +243,7 @@ impl NvApi {
         &self,
         handle: NvPhysicalGpuHandle,
         vram_type: Option<&str>,
-    ) -> anyhow::Result<Vec<u64>> {
+    ) -> anyhow::Result<Vec<(String, u64)>> {
         const REG_OFFSET_GDDR_TEMP_DATA_BASE: u32 = 0x009024C0;
         const REG_OFFSET_GDDR_TEMP_STATUS_BASE: u32 = 0x009024D0;
         const REG_OFFSET_GDDR_CLAMSHELL: u32 = 0x00900200;
@@ -254,26 +254,29 @@ impl NvApi {
 
         let mut temps = Vec::new();
 
-        match vram_type {
-            Some("GDDR6x") => {
-                let is_clamshell = unsafe {
-                    let value = self.read_u32_register(handle, REG_OFFSET_GDDR_CLAMSHELL)?;
-                    (value >> 22) == 1
-                };
+        if let Some("GDDR6x" | "GDDR7") = vram_type {
+            let is_clamshell = unsafe {
+                self.read_u32_register(handle, REG_OFFSET_GDDR_CLAMSHELL)
+                    .is_ok_and(|value| (value >> 22) & 1 == 1)
+            };
 
-                for partition in 0..=5 {
-                    let data_offset = REG_OFFSET_GDDR_TEMP_DATA_BASE + partition * 0x4000;
-                    let status_offset = REG_OFFSET_GDDR_TEMP_STATUS_BASE + partition * 0x4000;
+            for partition in 0..=8 {
+                let data_offset = REG_OFFSET_GDDR_TEMP_DATA_BASE + partition * 0x4000;
+                let status_offset = REG_OFFSET_GDDR_TEMP_STATUS_BASE + partition * 0x4000;
 
-                    unsafe {
-                        let status = self.read_u32_register(handle, status_offset)?;
+                unsafe {
+                    let Ok(status) = self.read_u32_register(handle, status_offset) else {
+                        continue;
+                    };
 
-                        // Explicit poison data
-                        if status & 0xFFFF0000 == 0xBADF0000 {
-                            continue;
-                        }
+                    // Explicit poison data
+                    if status & 0xFFFF0000 == 0xBADF0000 {
+                        continue;
+                    }
 
-                        for (slot, status_bit) in [(0x0, 24), (0x4, 25), (0x8, 26), (0xC, 27)] {
+                    let mut i = 0;
+                    'pairs: for slot_pair in [[(0x0, 24), (0x8, 26)], [(0x4, 25), (0xC, 27)]] {
+                        for (slot, status_bit) in slot_pair {
                             if (status >> status_bit) & 1 == 1 {
                                 let data = self.read_u32_register(handle, data_offset + slot)?;
 
@@ -290,18 +293,25 @@ impl NvApi {
                                 if pc0 == 0 || pc0 == u64::from(u8::MAX) {
                                     continue;
                                 }
-                                temps.push(parse_temp(pc0));
+
+                                let partition_letter = char::from_u32(('A' as u32) + partition)
+                                    .context("Invalid partition")?;
+                                let label = format!("{partition_letter}{i}");
+
+                                temps.push((label.clone(), parse_temp(pc0)));
 
                                 if is_clamshell && pc1 != 0 && pc1 != u64::from(u8::MAX) {
-                                    temps.push(parse_temp(pc1));
+                                    temps.push((format!("{label} (Back)"), parse_temp(pc1)));
                                 }
+
+                                i += 1;
+
+                                continue 'pairs;
                             }
                         }
                     }
                 }
             }
-            Some("GDDR7") => todo!(),
-            _ => (),
         }
 
         Ok(temps)

--- a/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
@@ -296,12 +296,18 @@ impl NvApi {
 
                                 let partition_letter = char::from_u32(('A' as u32) + partition)
                                     .context("Invalid partition")?;
-                                let label = format!("{partition_letter}{i}");
+                                let label_base = format!("{partition_letter}{i}");
 
-                                temps.push((label.clone(), parse_temp(pc0)));
+                                let front_label = if is_clamshell {
+                                    format!("{label_base} (Front)")
+                                } else {
+                                    label_base.clone()
+                                };
+
+                                temps.push((front_label, parse_temp(pc0)));
 
                                 if is_clamshell && pc1 != 0 && pc1 != u64::from(u8::MAX) {
-                                    temps.push((format!("{label} (Back)"), parse_temp(pc1)));
+                                    temps.push((format!("{label_base} (Back)"), parse_temp(pc1)));
                                 }
 
                                 i += 1;

--- a/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
+++ b/lact-daemon/src/server/gpu_controller/nvidia/nvapi.rs
@@ -239,6 +239,74 @@ impl NvApi {
         Ok(handles.into_iter().take(count as usize).collect())
     }
 
+    pub fn read_vram_temps(
+        &self,
+        handle: NvPhysicalGpuHandle,
+        vram_type: Option<&str>,
+    ) -> anyhow::Result<Vec<u64>> {
+        const REG_OFFSET_GDDR_TEMP_DATA_BASE: u32 = 0x009024C0;
+        const REG_OFFSET_GDDR_TEMP_STATUS_BASE: u32 = 0x009024D0;
+        const REG_OFFSET_GDDR_CLAMSHELL: u32 = 0x00900200;
+
+        fn parse_temp(raw: u64) -> u64 {
+            2 * raw.min(0x50) - 40
+        }
+
+        let mut temps = Vec::new();
+
+        match vram_type {
+            Some("GDDR6x") => {
+                let is_clamshell = unsafe {
+                    let value = self.read_u32_register(handle, REG_OFFSET_GDDR_CLAMSHELL)?;
+                    (value >> 22) == 1
+                };
+
+                for partition in 0..=5 {
+                    let data_offset = REG_OFFSET_GDDR_TEMP_DATA_BASE + partition * 0x4000;
+                    let status_offset = REG_OFFSET_GDDR_TEMP_STATUS_BASE + partition * 0x4000;
+
+                    unsafe {
+                        let status = self.read_u32_register(handle, status_offset)?;
+
+                        // Explicit poison data
+                        if status & 0xFFFF0000 == 0xBADF0000 {
+                            continue;
+                        }
+
+                        for (slot, status_bit) in [(0x0, 24), (0x4, 25), (0x8, 26), (0xC, 27)] {
+                            if (status >> status_bit) & 1 == 1 {
+                                let data = self.read_u32_register(handle, data_offset + slot)?;
+
+                                if data == 0
+                                    || data == u64::from(u32::MAX)
+                                    || data & 0xFFFF0000 == 0xBADF0000
+                                {
+                                    continue;
+                                }
+
+                                let pc0 = (data >> 16) & 0xFF;
+                                let pc1 = (data >> 24) & 0xFF;
+
+                                if pc0 == 0 || pc0 == u64::from(u8::MAX) {
+                                    continue;
+                                }
+                                temps.push(parse_temp(pc0));
+
+                                if is_clamshell && pc1 != 0 && pc1 != u64::from(u8::MAX) {
+                                    temps.push(parse_temp(pc1));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Some("GDDR7") => todo!(),
+            _ => (),
+        }
+
+        Ok(temps)
+    }
+
     pub unsafe fn read_blackwell_hotspot(
         &self,
         handle: NvPhysicalGpuHandle,

--- a/lact-gui/src/app/graphs_window/plot/imp.rs
+++ b/lact-gui/src/app/graphs_window/plot/imp.rs
@@ -106,6 +106,7 @@ mod benches {
         hw_mon::Temperature,
     };
     use divan::{Bencher, counter::ItemsCount};
+    use indexmap::IndexMap;
     use jiff::Timestamp;
     use lact_schema::{
         ActivePowerStates, ClockspeedStats, DeviceStats, FanStats, PmfwInfo, PowerStats,
@@ -190,7 +191,7 @@ mod benches {
                         current: None,
                         sensors: HashMap::new(),
                     },
-                    temps: HashMap::from([(
+                    temps: IndexMap::from([(
                         "edge".to_owned(),
                         TemperatureEntry {
                             value: Temperature {

--- a/lact-gui/src/app/pages/thermals_page/fan_curve_frame.rs
+++ b/lact-gui/src/app/pages/thermals_page/fan_curve_frame.rs
@@ -17,6 +17,7 @@ use gtk::{
     },
 };
 use i18n_embed_fl::fl;
+use indexmap::IndexMap;
 use lact_schema::{FanCurveMap, TemperatureEntry, default_fan_curve};
 use plotters::{
     chart::ChartBuilder,
@@ -35,7 +36,6 @@ use relm4::{
 };
 use std::{
     cell::{Cell, RefCell},
-    collections::HashMap,
     ops::RangeInclusive,
     rc::Rc,
     sync::atomic::{AtomicBool, Ordering},
@@ -94,7 +94,7 @@ pub(super) enum FanCurveFrameMsg {
 pub(super) struct CurveSetupMsg {
     pub curve: FanCurveMap,
     pub hw_based: bool,
-    pub current_temperatures: HashMap<String, TemperatureEntry>,
+    pub current_temperatures: IndexMap<String, TemperatureEntry>,
     pub temperature_key: Option<String>,
     pub speed_range: RangeInclusive<f32>,
     pub temperature_range: RangeInclusive<f32>,

--- a/lact-gui/src/app/utils/formatting.rs
+++ b/lact-gui/src/app/utils/formatting.rs
@@ -262,7 +262,7 @@ mod tests {
     }
 
     #[test]
-    fn fmt_temperature_text_sorts_labels() {
+    fn fmt_temperature_text_retains_order() {
         let stats = DeviceStats {
             temps: IndexMap::from([
                 (
@@ -295,7 +295,7 @@ mod tests {
 
         assert_eq!(
             fmt_temperature_text(&stats).0.join(", "),
-            "edge: <span font_family='monospace'>55</span>°C, junction: <span font_family='monospace'>80</span>°C".to_string()
+            "junction: <span font_family='monospace'>80</span>°C, edge: <span font_family='monospace'>55</span>°C".to_string()
         );
     }
 

--- a/lact-gui/src/app/utils/formatting.rs
+++ b/lact-gui/src/app/utils/formatting.rs
@@ -91,13 +91,10 @@ pub fn fmt_throttling_text(stats: &DeviceStats) -> String {
 const PRIMARY_TEMP_THRESHOLD: usize = 3;
 
 pub fn fmt_temperature_text(stats: &DeviceStats) -> (Vec<String>, Vec<String>) {
-    let (mut primary, mut secondary): (Vec<_>, Vec<_>) = stats
+    let (primary, secondary): (Vec<_>, Vec<_>) = stats
         .temps
         .iter()
         .partition(|(_, entry)| stats.temps.len() <= PRIMARY_TEMP_THRESHOLD || entry.primary);
-
-    primary.sort_unstable_by(|lhs, rhs| lhs.0.cmp(rhs.0));
-    secondary.sort_unstable_by(|lhs, rhs| lhs.0.cmp(rhs.0));
 
     let primary = primary
         .into_iter()
@@ -181,8 +178,9 @@ pub fn fmt_human_bytes(bytes: u64, unit: Option<ByteUnit>) -> String {
 mod tests {
     use super::*;
     use amdgpu_sysfs::hw_mon::Temperature;
+    use indexmap::IndexMap;
     use lact_schema::{DeviceStats, TemperatureEntry};
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::BTreeMap;
 
     #[test]
     fn mono_display_formats_values() {
@@ -266,7 +264,7 @@ mod tests {
     #[test]
     fn fmt_temperature_text_sorts_labels() {
         let stats = DeviceStats {
-            temps: HashMap::from([
+            temps: IndexMap::from([
                 (
                     "junction".to_string(),
                     TemperatureEntry {

--- a/lact-schema/src/lib.rs
+++ b/lact-schema/src/lib.rs
@@ -556,7 +556,7 @@ pub struct DeviceStats {
     pub voltage: VoltageStats,
     pub vram: VramStats,
     pub power: PowerStats,
-    pub temps: HashMap<String, TemperatureEntry>,
+    pub temps: IndexMap<String, TemperatureEntry>,
     pub busy_percent: Option<u8>,
     pub performance_level: Option<PerformanceLevel>,
     pub active_power_mizer_mode: Option<PowerMizerMode>,


### PR DESCRIPTION
This adds temperature readings per each VRAM chip on Nvidia. Tested to work on Ampere, Ada and Blackwell. For clamshell cards (ones that have memory on the front and the back of the PCB), both sides are shown:
<img width="915" height="591" alt="image" src="https://github.com/user-attachments/assets/364768ef-7092-4660-8212-f07bac90f47f" />


Big thanks for Paulo Gomes, who has helped by providing his register findings. 
Additional source: https://www.overclock.net/threads/official-nvidia-rtx-5090-owners-club.1814246/page-1918