### PR TITLE
chore: accumulate GPU reload events centrally

### DIFF
--- a/lact-daemon/src/lib.rs
+++ b/lact-daemon/src/lib.rs
@@ -14,12 +14,12 @@ use anyhow::Context;
 use config::Config;
 use futures::future::select_all;
 use server::{Server, handle_stream, handler::Handler};
+use std::os::unix::net::UnixStream as StdUnixStream;
 use std::sync::Arc;
-use std::{os::unix::net::UnixStream as StdUnixStream, time::Duration};
+use std::time::Duration;
 use tokio::net::UnixStream;
 use tokio::runtime::LocalOptions;
 use tokio::sync::Notify;
-use tokio::time::timeout;
 use tokio::{
     runtime,
     signal::unix::{SignalKind, signal},
@@ -31,7 +31,8 @@ use tracing_subscriber::EnvFilter;
 use crate::server::ClientContext;
 pub use system::BASE_MODULE_CONF_PATH;
 
-const DRM_EVENT_TIMEOUT_PERIOD_MS: u64 = 100;
+const DRM_EVENT_COLLECT_DURATION: Duration = Duration::from_millis(250);
+
 const SHUTDOWN_SIGNALS: [SignalKind; 4] = [
     SignalKind::terminate(),
     SignalKind::interrupt(),
@@ -134,16 +135,7 @@ async fn listen_device_events(handler: Handler) {
     loop {
         notify.notified().await;
 
-        // Wait until the timeout has passed with no new events coming in
-        while timeout(
-            Duration::from_millis(DRM_EVENT_TIMEOUT_PERIOD_MS),
-            notify.notified(),
-        )
-        .await
-        .is_ok()
-        {}
-
-        info!("got kernel drm subsystem event, reloading GPUs");
-        handler.reload_gpus().await;
+        info!("got kernel drm subsystem event, queueing GPU reload");
+        handler.notify_reload_gpus(DRM_EVENT_COLLECT_DURATION).await;
     }
 }

--- a/lact-daemon/src/lib.rs
+++ b/lact-daemon/src/lib.rs
@@ -31,7 +31,7 @@ use tracing_subscriber::EnvFilter;
 use crate::server::ClientContext;
 pub use system::BASE_MODULE_CONF_PATH;
 
-const DRM_EVENT_COLLECT_DURATION: Duration = Duration::from_millis(250);
+const DRM_EVENT_COLLECT_DURATION: Duration = Duration::from_millis(500);
 
 const SHUTDOWN_SIGNALS: [SignalKind; 4] = [
     SignalKind::terminate(),

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -49,6 +49,7 @@ use std::{
 };
 use tokio::{
     process::Command,
+    select,
     sync::{RwLock, RwLockReadGuard, mpsc, oneshot},
     task::JoinHandle,
     time::sleep,
@@ -107,6 +108,7 @@ pub struct Handler {
     next_hold_cookie: Rc<Cell<u64>>,
     polkit_proxy: Option<AuthorityProxy<'static>>,
     ignored_gpu_ids: Rc<RwLock<Vec<String>>>,
+    reload_tx: Rc<mpsc::Sender<Duration>>,
 }
 
 impl<'a> Handler {
@@ -191,6 +193,8 @@ impl<'a> Handler {
             })
             .ok();
 
+        let (reload_tx, reload_rx) = mpsc::channel(16);
+
         let handler = Self {
             gpu_controllers: Rc::new(RwLock::new(controllers)),
             config: Rc::new(RwLock::new(config)),
@@ -204,7 +208,9 @@ impl<'a> Handler {
             next_hold_cookie: Rc::new(Cell::new(1)),
             polkit_proxy,
             ignored_gpu_ids: Rc::new(RwLock::new(Vec::new())),
+            reload_tx: Rc::new(reload_tx),
         };
+
         if let Err(err) = handler.apply_current_config().await {
             error!("could not apply config: {err:#}");
         }
@@ -216,6 +222,8 @@ impl<'a> Handler {
         if handler.config.read().await.auto_switch_profiles {
             handler.start_profile_watcher().await;
         }
+
+        tokio::task::spawn_local(handle_reload_events(handler.clone(), reload_rx));
 
         // Eagerly release memory
         // `load_controllers` allocates and deallocates the entire PCI ID database,
@@ -234,7 +242,11 @@ impl<'a> Handler {
         apply_config_to_controllers(&controllers, &config).await
     }
 
-    pub async fn reload_gpus(&self) {
+    pub async fn notify_reload_gpus(&self, accum_interval: Duration) {
+        self.reload_tx.send(accum_interval).await.unwrap();
+    }
+
+    async fn reload_gpus(&self) {
         let mut controllers_guard = self.gpu_controllers.write().await;
         let config = self.config.read().await;
         let detached_ids = self.ignored_gpu_ids.read().await;
@@ -1573,4 +1585,31 @@ async fn connect_polkit_proxy() -> anyhow::Result<AuthorityProxy<'static>> {
         .context("Could not connect to polkit")?;
 
     Ok(proxy)
+}
+
+async fn handle_reload_events(handler: Handler, mut rx: mpsc::Receiver<Duration>) {
+    // Reload events often come in quick succession (usually from DRM devices initializing),
+    // this accumulation avoids unnecessarily reloading multiple times in such cases.
+    while let Some(interval) = rx.recv().await {
+        let timeout = sleep(interval);
+        tokio::pin!(timeout);
+
+        loop {
+            select! {
+                () = &mut timeout => {
+                    break
+                },
+                Some(new_interval) = rx.recv() => {
+                    let new_deadline = tokio::time::Instant::now() + new_interval;
+                    if new_deadline > timeout.deadline() {
+                        debug!("got another reload event in shrot interval, delaying reload");
+                        timeout.as_mut().reset(new_deadline);
+                    }
+                }
+            }
+        }
+
+        info!("got reload event, reloading GPUs");
+        handler.reload_gpus().await;
+    }
 }

--- a/lact-daemon/src/suspend.rs
+++ b/lact-daemon/src/suspend.rs
@@ -2,20 +2,28 @@ use crate::server::handler::Handler;
 use futures::StreamExt;
 use std::time::Duration;
 use tracing::{error, info};
-use zbus::{Connection, Proxy};
+use zbus::{Connection, proxy};
 
-const SUSPEND_EVENT_COLLECT_DURATION: Duration = Duration::from_secs(3);
+const SUSPEND_EVENT_COLLECT_DURATION: Duration = Duration::from_secs(2);
 
 pub async fn listen_events(handler: Handler) {
     match connect_proxy().await {
-        // Note: despite the name, the events get triggered both on suspend and resume
-        Ok(proxy) => match proxy.receive_signal("PrepareForSleep").await {
+        Ok(proxy) => match proxy.receive_prepare_for_sleep().await {
             Ok(mut stream) => {
-                while stream.next().await.is_some() {
-                    info!("suspend/resume event detected, queueing config reload");
-                    handler
-                        .notify_reload_gpus(SUSPEND_EVENT_COLLECT_DURATION)
-                        .await;
+                while let Some(value) = stream.next().await {
+                    match value.args() {
+                        Ok(args) => {
+                            if !args.start {
+                                info!("resume event detected, queueing config reload");
+                                handler
+                                    .notify_reload_gpus(SUSPEND_EVENT_COLLECT_DURATION)
+                                    .await;
+                            }
+                        }
+                        Err(err) => {
+                            error!("could not get sleep events args: {err}");
+                        }
+                    }
                 }
             }
             Err(err) => error!("could not subscribe to suspend events: {err:#}"),
@@ -27,14 +35,19 @@ pub async fn listen_events(handler: Handler) {
     error!("suspend/resume events will not be handled.");
 }
 
-async fn connect_proxy() -> anyhow::Result<Proxy<'static>> {
+async fn connect_proxy() -> anyhow::Result<LoginManagerProxy<'static>> {
     let conn = Box::pin(Connection::system()).await?;
-    let proxy = Proxy::new_owned(
-        conn,
-        "org.freedesktop.login1",
-        "/org/freedesktop/login1",
-        "org.freedesktop.login1.Manager",
-    )
-    .await?;
+    let proxy = LoginManagerProxy::new(&conn).await?;
     Ok(proxy)
+}
+
+#[proxy(
+    interface = "org.freedesktop.login1.Manager",
+    default_service = "org.freedesktop.login1",
+    default_path = "/org/freedesktop/login1"
+)]
+pub trait LoginManager {
+    // Note: despite the name, the events get triggered both on suspend and resume. `start` is false on resume
+    #[zbus(signal)]
+    fn prepare_for_sleep(&self, start: bool) -> zbus::Result<()>;
 }

--- a/lact-daemon/src/suspend.rs
+++ b/lact-daemon/src/suspend.rs
@@ -1,7 +1,10 @@
 use crate::server::handler::Handler;
 use futures::StreamExt;
+use std::time::Duration;
 use tracing::{error, info};
 use zbus::{Connection, Proxy};
+
+const SUSPEND_EVENT_COLLECT_DURATION: Duration = Duration::from_secs(3);
 
 pub async fn listen_events(handler: Handler) {
     match connect_proxy().await {
@@ -9,8 +12,10 @@ pub async fn listen_events(handler: Handler) {
         Ok(proxy) => match proxy.receive_signal("PrepareForSleep").await {
             Ok(mut stream) => {
                 while stream.next().await.is_some() {
-                    info!("suspend/resume event detected, reloading config");
-                    handler.reload_gpus().await;
+                    info!("suspend/resume event detected, queueing config reload");
+                    handler
+                        .notify_reload_gpus(SUSPEND_EVENT_COLLECT_DURATION)
+                        .await;
                 }
             }
             Err(err) => error!("could not subscribe to suspend events: {err:#}"),

--- a/lact-daemon/src/tests/mod.rs
+++ b/lact-daemon/src/tests/mod.rs
@@ -19,7 +19,7 @@ fn init_tracing() {
     });
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "local")]
 #[cfg_attr(miri, ignore)]
 async fn snapshot_everything() {
     init_tracing();


### PR DESCRIPTION
Some events (in particular suspend/resume) create many GPU reload notifications at once. Currently, they might be redundantly handled multiple times. With this change, they are accumulated regardless of their source, and for suspend specifically there is a big grace interval (3 seconds) to avoid touching things during driver init.

Might potentially help #1120.