### PR TITLE
Ignoring intel_pmt on test snapshots

### DIFF
--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -85,6 +85,7 @@ const SNAPSHOT_EXCLUDED_FILENAME_PREFIXES: &[&str] = &[
     "pcie_bw",
     "msi_irqs",
     "mtd",
+    "intel_pmt"
 ];
 const CONFIG_RESET_CMDLINE_ARG: &str = "lact-reset";
 

--- a/lact-daemon/src/server/handler.rs
+++ b/lact-daemon/src/server/handler.rs
@@ -85,7 +85,7 @@ const SNAPSHOT_EXCLUDED_FILENAME_PREFIXES: &[&str] = &[
     "pcie_bw",
     "msi_irqs",
     "mtd",
-    "intel_pmt"
+    "intel_pmt",
 ];
 const CONFIG_RESET_CMDLINE_ARG: &str = "lact-reset";
 


### PR DESCRIPTION
This Pull Request makes the test snapshot ignore the `intel_pmt`. For some reason, when LACT tries to read that, the Linux kernel decides to crash. Tested on 7.1.5, 7.2-rc4, 7.2-rc5.

Discovered by @ilya-zlobintsev on https://github.com/ilya-zlobintsev/LACT/pull/1108#issuecomment-5313272993 and I decided to have a new Pull Request to keep things separated