### PR TITLE
Update flatbox to 0.0.14

### DIFF
--- a/flatpak/io.github.ilya_zlobintsev.LACT.yaml
+++ b/flatpak/io.github.ilya_zlobintsev.LACT.yaml
@@ -98,15 +98,15 @@ modules:
       - type: archive
         only-arches:
           - x86_64
-        url: https://github.com/ilya-zlobintsev/flatbox/releases/download/v0.0.13/flatbox-Linux-musl-x86_64.tar.gz
+        url: https://github.com/ilya-zlobintsev/flatbox/releases/download/v0.0.14/flatbox-Linux-musl-x86_64.tar.gz
         strip-components: 0
-        sha256: 6342687d90fcf5ae8404e374348eb4b0c9afde5dcb127b258289833f92e50cea
+        sha256: b13ecb1cd79831c9c0cb56f61da9ad6abff188eb0909e3e98d243054418ad129
       - type: archive
         only-arches:
           - aarch64
-        url: https://github.com/ilya-zlobintsev/flatbox/releases/download/v0.0.13/flatbox-Linux-musl-arm64.tar.gz
+        url: https://github.com/ilya-zlobintsev/flatbox/releases/download/v0.0.14/flatbox-Linux-musl-arm64.tar.gz
         strip-components: 0
-        sha256: 2372c9a13aca4cd2342946a1ba400ae4459af7744836e1e0698ba93313d16895
+        sha256: ecceae9d69593a465aeb39618cdd0799719fb704a836ffedd428a3349c095106
 
   - name: hwdata
     config-opts:

--- a/flatpak/io.github.ilya_zlobintsev.LACT.yaml
+++ b/flatpak/io.github.ilya_zlobintsev.LACT.yaml
@@ -98,15 +98,15 @@ modules:
       - type: archive
         only-arches:
           - x86_64
-        url: https://github.com/ilya-zlobintsev/flatbox/releases/download/v0.0.12/flatbox-Linux-musl-x86_64.tar.gz
+        url: https://github.com/ilya-zlobintsev/flatbox/releases/download/v0.0.13/flatbox-Linux-musl-x86_64.tar.gz
         strip-components: 0
-        sha256: de32e42d27fce5113d3e3148d2bfee8020cc180df4c365c92efde27d02fc398e
+        sha256: 6342687d90fcf5ae8404e374348eb4b0c9afde5dcb127b258289833f92e50cea
       - type: archive
         only-arches:
           - aarch64
-        url: https://github.com/ilya-zlobintsev/flatbox/releases/download/v0.0.12/flatbox-Linux-musl-arm64.tar.gz
+        url: https://github.com/ilya-zlobintsev/flatbox/releases/download/v0.0.13/flatbox-Linux-musl-arm64.tar.gz
         strip-components: 0
-        sha256: a32ededf08fca1b0c075401ec400881539156c12b97f10f62a17803f1b9d304b
+        sha256: 2372c9a13aca4cd2342946a1ba400ae4459af7744836e1e0698ba93313d16895
 
   - name: hwdata
     config-opts:


### PR DESCRIPTION
Should handle https://github.com/ilya-zlobintsev/LACT/issues/1188, also brings in improvements for avoiding massive cmdlines by passing args via a file descriptor.